### PR TITLE
Adds last raid column to attendance table; formatting

### DIFF
--- a/MainClass.cs
+++ b/MainClass.cs
@@ -215,6 +215,13 @@ namespace ES_DKP_Utils
             set { _GuildNames = value; }
         }
 
+        private System.Int32 _RaidDaysWindow;
+        public System.Int32 RaidDaysWindow
+        {
+            get { return _RaidDaysWindow; }
+            set { _RaidDaysWindow = value; }
+        }
+
 		private string _ItemDKP = "B";
 		public string ItemDKP
 		{
@@ -318,6 +325,7 @@ namespace ES_DKP_Utils
                 TierCPct = inifile.Configs["Other"].GetDouble("tiercpct", 0.0);
                 GuildNames = inifile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
                 AutomaticBackups = inifile.Configs["Other"].GetBoolean("AutomaticBackups", true);
+                RaidDaysWindow = inifile.Configs["Other"].GetInt("RaidDaysWindow", 20);
                 log.Info("Read settings from INI: DBFile=" + DBString + ", LogFile=" + LogFile + ", OutputDirectory="
                     + OutputDirectory + ", DKPTax=" + DKPTax + ", GuildNames=" + GuildNames);
 
@@ -354,6 +362,7 @@ namespace ES_DKP_Utils
                     TierBPct = inifile.Configs["Other"].GetDouble("tierbpct", 0.3);
                     TierCPct = inifile.Configs["Other"].GetDouble("tiercpct", 0.0);
                     GuildNames = inifile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
+                    RaidDaysWindow = inifile.Configs["Other"].GetInt("RaidDaysWindow", 20);
                     AutomaticBackups = inifile.Configs["Other"].GetBoolean("AutomaticBackups", true);
 					inifile.Save();
 					log.Info("Read settings from INI: dbFile=" + DBString + ", logFile=" + LogFile
@@ -1273,7 +1282,7 @@ namespace ES_DKP_Utils
             // 
             // stbStatusBar
             // 
-            this.stbStatusBar.Location = new System.Drawing.Point(0, 518);
+            this.stbStatusBar.Location = new System.Drawing.Point(0, 281);
             this.stbStatusBar.Name = "stbStatusBar";
             this.stbStatusBar.Panels.AddRange(new System.Windows.Forms.StatusBarPanel[] {
             this.sbpMessage,
@@ -1281,7 +1290,7 @@ namespace ES_DKP_Utils
             this.sbpLineCount,
             this.sbpParseCount});
             this.stbStatusBar.ShowPanels = true;
-            this.stbStatusBar.Size = new System.Drawing.Size(1192, 44);
+            this.stbStatusBar.Size = new System.Drawing.Size(564, 23);
             this.stbStatusBar.SizingGrip = false;
             this.stbStatusBar.TabIndex = 0;
             // 
@@ -1333,52 +1342,48 @@ namespace ES_DKP_Utils
             this.panel.Controls.Add(this.lblRaidDate);
             this.panel.Controls.Add(this.lblRaidName);
             this.panel.Enabled = false;
-            this.panel.Location = new System.Drawing.Point(14, 15);
+            this.panel.Location = new System.Drawing.Point(7, 8);
             this.panel.Name = "panel";
-            this.panel.Size = new System.Drawing.Size(1112, 489);
+            this.panel.Size = new System.Drawing.Size(556, 265);
             this.panel.TabIndex = 1;
             // 
             // listOfAttd
             // 
-            this.listOfAttd.ItemHeight = 25;
-            this.listOfAttd.Location = new System.Drawing.Point(1028, 30);
+            this.listOfAttd.Location = new System.Drawing.Point(514, 16);
             this.listOfAttd.Name = "listOfAttd";
-            this.listOfAttd.Size = new System.Drawing.Size(74, 329);
+            this.listOfAttd.Size = new System.Drawing.Size(37, 173);
             this.listOfAttd.TabIndex = 34;
             this.listOfAttd.TabStop = false;
             // 
             // listOfDKP
             // 
-            this.listOfDKP.ItemHeight = 25;
-            this.listOfDKP.Location = new System.Drawing.Point(872, 30);
+            this.listOfDKP.Location = new System.Drawing.Point(436, 16);
             this.listOfDKP.Name = "listOfDKP";
-            this.listOfDKP.Size = new System.Drawing.Size(144, 329);
+            this.listOfDKP.Size = new System.Drawing.Size(72, 173);
             this.listOfDKP.TabIndex = 14;
             this.listOfDKP.TabStop = false;
             // 
             // listOfTiers
             // 
-            this.listOfTiers.ItemHeight = 25;
-            this.listOfTiers.Location = new System.Drawing.Point(812, 30);
+            this.listOfTiers.Location = new System.Drawing.Point(406, 16);
             this.listOfTiers.Name = "listOfTiers";
-            this.listOfTiers.Size = new System.Drawing.Size(48, 329);
+            this.listOfTiers.Size = new System.Drawing.Size(24, 173);
             this.listOfTiers.TabIndex = 13;
             this.listOfTiers.TabStop = false;
             // 
             // listOfNames
             // 
-            this.listOfNames.ItemHeight = 25;
-            this.listOfNames.Location = new System.Drawing.Point(544, 30);
+            this.listOfNames.Location = new System.Drawing.Point(272, 16);
             this.listOfNames.Name = "listOfNames";
-            this.listOfNames.Size = new System.Drawing.Size(256, 329);
+            this.listOfNames.Size = new System.Drawing.Size(128, 173);
             this.listOfNames.TabIndex = 12;
             this.listOfNames.TabStop = false;
             // 
             // txtZoneNames
             // 
-            this.txtZoneNames.Location = new System.Drawing.Point(16, 436);
+            this.txtZoneNames.Location = new System.Drawing.Point(8, 236);
             this.txtZoneNames.Name = "txtZoneNames";
-            this.txtZoneNames.Size = new System.Drawing.Size(516, 31);
+            this.txtZoneNames.Size = new System.Drawing.Size(258, 20);
             this.txtZoneNames.TabIndex = 13;
             // 
             // grpWatchFor
@@ -1386,9 +1391,9 @@ namespace ES_DKP_Utils
             this.grpWatchFor.Controls.Add(this.chkLoot);
             this.grpWatchFor.Controls.Add(this.chkWho);
             this.grpWatchFor.Controls.Add(this.chkTells);
-            this.grpWatchFor.Location = new System.Drawing.Point(296, 114);
+            this.grpWatchFor.Location = new System.Drawing.Point(148, 62);
             this.grpWatchFor.Name = "grpWatchFor";
-            this.grpWatchFor.Size = new System.Drawing.Size(236, 174);
+            this.grpWatchFor.Size = new System.Drawing.Size(118, 94);
             this.grpWatchFor.TabIndex = 36;
             this.grpWatchFor.TabStop = false;
             this.grpWatchFor.Text = "Watch For...";
@@ -1396,9 +1401,9 @@ namespace ES_DKP_Utils
             // chkLoot
             // 
             this.chkLoot.AutoSize = true;
-            this.chkLoot.Location = new System.Drawing.Point(14, 122);
+            this.chkLoot.Location = new System.Drawing.Point(7, 66);
             this.chkLoot.Name = "chkLoot";
-            this.chkLoot.Size = new System.Drawing.Size(86, 29);
+            this.chkLoot.Size = new System.Drawing.Size(47, 17);
             this.chkLoot.TabIndex = 2;
             this.chkLoot.Text = "Loot";
             this.chkLoot.UseVisualStyleBackColor = true;
@@ -1407,9 +1412,9 @@ namespace ES_DKP_Utils
             // chkWho
             // 
             this.chkWho.AutoSize = true;
-            this.chkWho.Location = new System.Drawing.Point(14, 79);
+            this.chkWho.Location = new System.Drawing.Point(7, 43);
             this.chkWho.Name = "chkWho";
-            this.chkWho.Size = new System.Drawing.Size(89, 29);
+            this.chkWho.Size = new System.Drawing.Size(51, 17);
             this.chkWho.TabIndex = 1;
             this.chkWho.Text = "/who";
             this.chkWho.UseVisualStyleBackColor = true;
@@ -1418,9 +1423,9 @@ namespace ES_DKP_Utils
             // chkTells
             // 
             this.chkTells.AutoSize = true;
-            this.chkTells.Location = new System.Drawing.Point(14, 37);
+            this.chkTells.Location = new System.Drawing.Point(7, 20);
             this.chkTells.Name = "chkTells";
-            this.chkTells.Size = new System.Drawing.Size(90, 29);
+            this.chkTells.Size = new System.Drawing.Size(48, 17);
             this.chkTells.TabIndex = 0;
             this.chkTells.Text = "Tells";
             this.chkTells.UseVisualStyleBackColor = true;
@@ -1428,17 +1433,17 @@ namespace ES_DKP_Utils
             // 
             // lblAttd
             // 
-            this.lblAttd.Location = new System.Drawing.Point(1022, 2);
+            this.lblAttd.Location = new System.Drawing.Point(511, 1);
             this.lblAttd.Name = "lblAttd";
-            this.lblAttd.Size = new System.Drawing.Size(64, 29);
+            this.lblAttd.Size = new System.Drawing.Size(32, 16);
             this.lblAttd.TabIndex = 35;
             this.lblAttd.Text = "Attd:";
             // 
             // btnClear
             // 
-            this.btnClear.Location = new System.Drawing.Point(964, 414);
+            this.btnClear.Location = new System.Drawing.Point(482, 224);
             this.btnClear.Name = "btnClear";
-            this.btnClear.Size = new System.Drawing.Size(138, 44);
+            this.btnClear.Size = new System.Drawing.Size(69, 24);
             this.btnClear.TabIndex = 33;
             this.btnClear.Text = "Clear Tells";
             this.btnClear.Click += new System.EventHandler(this.btnClear_Click);
@@ -1446,63 +1451,63 @@ namespace ES_DKP_Utils
             // dtpRaidDate
             // 
             this.dtpRaidDate.Format = System.Windows.Forms.DateTimePickerFormat.Short;
-            this.dtpRaidDate.Location = new System.Drawing.Point(150, 22);
+            this.dtpRaidDate.Location = new System.Drawing.Point(75, 12);
             this.dtpRaidDate.Name = "dtpRaidDate";
-            this.dtpRaidDate.Size = new System.Drawing.Size(256, 31);
+            this.dtpRaidDate.Size = new System.Drawing.Size(128, 20);
             this.dtpRaidDate.TabIndex = 1;
             this.dtpRaidDate.Value = new System.DateTime(2006, 5, 20, 0, 0, 0, 0);
             this.dtpRaidDate.ValueChanged += new System.EventHandler(this.dtpRaidDate_ValueChanged);
             // 
             // btnRemove
             // 
-            this.btnRemove.Location = new System.Drawing.Point(16, 185);
+            this.btnRemove.Location = new System.Drawing.Point(8, 100);
             this.btnRemove.Name = "btnRemove";
-            this.btnRemove.Size = new System.Drawing.Size(128, 59);
+            this.btnRemove.Size = new System.Drawing.Size(64, 32);
             this.btnRemove.TabIndex = 6;
             this.btnRemove.Text = "Remove Person";
             this.btnRemove.Click += new System.EventHandler(this.btnRemove_Click);
             // 
             // btnAdd
             // 
-            this.btnAdd.Location = new System.Drawing.Point(16, 114);
+            this.btnAdd.Location = new System.Drawing.Point(8, 62);
             this.btnAdd.Name = "btnAdd";
-            this.btnAdd.Size = new System.Drawing.Size(128, 60);
+            this.btnAdd.Size = new System.Drawing.Size(64, 32);
             this.btnAdd.TabIndex = 3;
             this.btnAdd.Text = "Add Person";
             this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
             // 
             // chkDouble
             // 
-            this.chkDouble.Location = new System.Drawing.Point(310, 299);
+            this.chkDouble.Location = new System.Drawing.Point(155, 162);
             this.chkDouble.Name = "chkDouble";
-            this.chkDouble.Size = new System.Drawing.Size(176, 30);
+            this.chkDouble.Size = new System.Drawing.Size(88, 16);
             this.chkDouble.TabIndex = 12;
             this.chkDouble.Text = "Double Tier";
             this.chkDouble.CheckedChanged += new System.EventHandler(this.chkDouble_CheckedChanged);
             // 
             // lblZoneNames
             // 
-            this.lblZoneNames.Location = new System.Drawing.Point(10, 390);
+            this.lblZoneNames.Location = new System.Drawing.Point(5, 211);
             this.lblZoneNames.Name = "lblZoneNames";
-            this.lblZoneNames.Size = new System.Drawing.Size(292, 44);
+            this.lblZoneNames.Size = new System.Drawing.Size(146, 24);
             this.lblZoneNames.TabIndex = 28;
             this.lblZoneNames.Text = "Raid Zone Shortname(s):";
             this.lblZoneNames.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // btnSaveRaid
             // 
-            this.btnSaveRaid.Location = new System.Drawing.Point(156, 325);
+            this.btnSaveRaid.Location = new System.Drawing.Point(78, 176);
             this.btnSaveRaid.Name = "btnSaveRaid";
-            this.btnSaveRaid.Size = new System.Drawing.Size(128, 59);
+            this.btnSaveRaid.Size = new System.Drawing.Size(64, 32);
             this.btnSaveRaid.TabIndex = 10;
             this.btnSaveRaid.Text = "Save Raid";
             this.btnSaveRaid.Click += new System.EventHandler(this.btnSaveRaid_Click);
             // 
             // btnRecordLoot
             // 
-            this.btnRecordLoot.Location = new System.Drawing.Point(156, 114);
+            this.btnRecordLoot.Location = new System.Drawing.Point(78, 62);
             this.btnRecordLoot.Name = "btnRecordLoot";
-            this.btnRecordLoot.Size = new System.Drawing.Size(128, 60);
+            this.btnRecordLoot.Size = new System.Drawing.Size(64, 32);
             this.btnRecordLoot.TabIndex = 7;
             this.btnRecordLoot.Text = "Record Loot";
             this.btnRecordLoot.Click += new System.EventHandler(this.btnRecordLoot_Click);
@@ -1513,9 +1518,9 @@ namespace ES_DKP_Utils
             this.grpItemTier.Controls.Add(this.rdoA);
             this.grpItemTier.Controls.Add(this.rdoB);
             this.grpItemTier.Controls.Add(this.rdoC);
-            this.grpItemTier.Location = new System.Drawing.Point(544, 384);
+            this.grpItemTier.Location = new System.Drawing.Point(272, 208);
             this.grpItemTier.Name = "grpItemTier";
-            this.grpItemTier.Size = new System.Drawing.Size(324, 89);
+            this.grpItemTier.Size = new System.Drawing.Size(162, 48);
             this.grpItemTier.TabIndex = 22;
             this.grpItemTier.TabStop = false;
             this.grpItemTier.Text = "Item Tier";
@@ -1523,9 +1528,9 @@ namespace ES_DKP_Utils
             // rdoATTD
             // 
             this.rdoATTD.Appearance = System.Windows.Forms.Appearance.Button;
-            this.rdoATTD.Location = new System.Drawing.Point(204, 30);
+            this.rdoATTD.Location = new System.Drawing.Point(102, 16);
             this.rdoATTD.Name = "rdoATTD";
-            this.rdoATTD.Size = new System.Drawing.Size(108, 44);
+            this.rdoATTD.Size = new System.Drawing.Size(54, 24);
             this.rdoATTD.TabIndex = 17;
             this.rdoATTD.Text = "ATTD";
             this.rdoATTD.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -1534,9 +1539,9 @@ namespace ES_DKP_Utils
             // rdoA
             // 
             this.rdoA.Appearance = System.Windows.Forms.Appearance.Button;
-            this.rdoA.Location = new System.Drawing.Point(16, 30);
+            this.rdoA.Location = new System.Drawing.Point(8, 16);
             this.rdoA.Name = "rdoA";
-            this.rdoA.Size = new System.Drawing.Size(48, 44);
+            this.rdoA.Size = new System.Drawing.Size(24, 24);
             this.rdoA.TabIndex = 14;
             this.rdoA.Text = "A";
             this.rdoA.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -1545,9 +1550,9 @@ namespace ES_DKP_Utils
             // rdoB
             // 
             this.rdoB.Appearance = System.Windows.Forms.Appearance.Button;
-            this.rdoB.Location = new System.Drawing.Point(80, 30);
+            this.rdoB.Location = new System.Drawing.Point(40, 16);
             this.rdoB.Name = "rdoB";
-            this.rdoB.Size = new System.Drawing.Size(48, 44);
+            this.rdoB.Size = new System.Drawing.Size(24, 24);
             this.rdoB.TabIndex = 15;
             this.rdoB.Text = "B";
             this.rdoB.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -1556,9 +1561,9 @@ namespace ES_DKP_Utils
             // rdoC
             // 
             this.rdoC.Appearance = System.Windows.Forms.Appearance.Button;
-            this.rdoC.Location = new System.Drawing.Point(144, 30);
+            this.rdoC.Location = new System.Drawing.Point(72, 16);
             this.rdoC.Name = "rdoC";
-            this.rdoC.Size = new System.Drawing.Size(48, 44);
+            this.rdoC.Size = new System.Drawing.Size(24, 24);
             this.rdoC.TabIndex = 16;
             this.rdoC.Text = "C";
             this.rdoC.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -1566,85 +1571,85 @@ namespace ES_DKP_Utils
             // 
             // dkpLabel
             // 
-            this.dkpLabel.Location = new System.Drawing.Point(866, 2);
+            this.dkpLabel.Location = new System.Drawing.Point(433, 1);
             this.dkpLabel.Name = "dkpLabel";
-            this.dkpLabel.Size = new System.Drawing.Size(112, 29);
+            this.dkpLabel.Size = new System.Drawing.Size(56, 16);
             this.dkpLabel.TabIndex = 17;
             this.dkpLabel.Text = "DKP:";
             // 
             // lblTier
             // 
-            this.lblTier.Location = new System.Drawing.Point(810, 2);
+            this.lblTier.Location = new System.Drawing.Point(405, 1);
             this.lblTier.Name = "lblTier";
-            this.lblTier.Size = new System.Drawing.Size(64, 29);
+            this.lblTier.Size = new System.Drawing.Size(32, 16);
             this.lblTier.TabIndex = 16;
             this.lblTier.Text = "Tier:";
             // 
             // lblName
             // 
-            this.lblName.Location = new System.Drawing.Point(538, 2);
+            this.lblName.Location = new System.Drawing.Point(269, 1);
             this.lblName.Name = "lblName";
-            this.lblName.Size = new System.Drawing.Size(144, 29);
+            this.lblName.Size = new System.Drawing.Size(72, 16);
             this.lblName.TabIndex = 15;
             this.lblName.Text = "Name:";
             // 
             // btnLoot
             // 
-            this.btnLoot.Location = new System.Drawing.Point(16, 325);
+            this.btnLoot.Location = new System.Drawing.Point(8, 176);
             this.btnLoot.Name = "btnLoot";
-            this.btnLoot.Size = new System.Drawing.Size(128, 59);
+            this.btnLoot.Size = new System.Drawing.Size(64, 32);
             this.btnLoot.TabIndex = 5;
             this.btnLoot.Text = "View Loot";
             this.btnLoot.Click += new System.EventHandler(this.btnLoot_Click);
             // 
             // btnAttendees
             // 
-            this.btnAttendees.Location = new System.Drawing.Point(16, 255);
+            this.btnAttendees.Location = new System.Drawing.Point(8, 138);
             this.btnAttendees.Name = "btnAttendees";
-            this.btnAttendees.Size = new System.Drawing.Size(128, 59);
+            this.btnAttendees.Size = new System.Drawing.Size(64, 32);
             this.btnAttendees.TabIndex = 4;
             this.btnAttendees.Text = "View Attendees";
             this.btnAttendees.Click += new System.EventHandler(this.btnAttendees_Click);
             // 
             // txtRaidName
             // 
-            this.txtRaidName.Location = new System.Drawing.Point(150, 66);
+            this.txtRaidName.Location = new System.Drawing.Point(75, 36);
             this.txtRaidName.Name = "txtRaidName";
-            this.txtRaidName.Size = new System.Drawing.Size(382, 31);
+            this.txtRaidName.Size = new System.Drawing.Size(191, 20);
             this.txtRaidName.TabIndex = 2;
             this.txtRaidName.Leave += new System.EventHandler(this.txtRaidName_Leave);
             // 
             // lblRaidDate
             // 
-            this.lblRaidDate.Location = new System.Drawing.Point(10, 30);
+            this.lblRaidDate.Location = new System.Drawing.Point(5, 16);
             this.lblRaidDate.Name = "lblRaidDate";
-            this.lblRaidDate.Size = new System.Drawing.Size(128, 29);
+            this.lblRaidDate.Size = new System.Drawing.Size(64, 16);
             this.lblRaidDate.TabIndex = 1;
             this.lblRaidDate.Text = "Raid Date:";
             this.lblRaidDate.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lblRaidName
             // 
-            this.lblRaidName.Location = new System.Drawing.Point(10, 68);
+            this.lblRaidName.Location = new System.Drawing.Point(5, 37);
             this.lblRaidName.Name = "lblRaidName";
-            this.lblRaidName.Size = new System.Drawing.Size(128, 30);
+            this.lblRaidName.Size = new System.Drawing.Size(64, 16);
             this.lblRaidName.TabIndex = 0;
             this.lblRaidName.Text = "Raid Name:";
             this.lblRaidName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // pgbProgress
             // 
-            this.pgbProgress.Location = new System.Drawing.Point(558, 521);
+            this.pgbProgress.Location = new System.Drawing.Point(279, 282);
             this.pgbProgress.Name = "pgbProgress";
-            this.pgbProgress.Size = new System.Drawing.Size(206, 40);
+            this.pgbProgress.Size = new System.Drawing.Size(103, 22);
             this.pgbProgress.Step = 1;
             this.pgbProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             this.pgbProgress.TabIndex = 2;
             // 
             // frmMain
             // 
-            this.AutoScaleBaseSize = new System.Drawing.Size(10, 24);
-            this.ClientSize = new System.Drawing.Size(1192, 562);
+            this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
+            this.ClientSize = new System.Drawing.Size(564, 304);
             this.Controls.Add(this.pgbProgress);
             this.Controls.Add(this.panel);
             this.Controls.Add(this.stbStatusBar);

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -286,6 +286,8 @@ namespace ES_DKP_Utils
         }
         #endregion
 
+        public int LastRaidDaysThreshold { get; set; }
+
         private IConfigSource inifile;
         private LogParser parser;
         private IContainer components;
@@ -326,6 +328,7 @@ namespace ES_DKP_Utils
                 GuildNames = inifile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
                 AutomaticBackups = inifile.Configs["Other"].GetBoolean("AutomaticBackups", true);
                 RaidDaysWindow = inifile.Configs["Other"].GetInt("RaidDaysWindow", 20);
+                LastRaidDaysThreshold = inifile.Configs["Other"].GetInt("LastRaidDaysThreshold", 7);
                 log.Info("Read settings from INI: DBFile=" + DBString + ", LogFile=" + LogFile + ", OutputDirectory="
                     + OutputDirectory + ", DKPTax=" + DKPTax + ", GuildNames=" + GuildNames);
 

--- a/Raid.cs
+++ b/Raid.cs
@@ -1143,8 +1143,8 @@ namespace ES_DKP_Utils
                 sw2.Write("[td][b][i]" + i + "[/i][/b][/td]");
                 i++;
             }
-            sw.Write("<td width='15%'><b><i>DKP Net Change</b></i></td><td width='15%'><b><i>DKP Total</b></i><td width='15'></td><td width='*'><b><i>Tier</b></i></td><td width='10'><i><b>Age</i></b></td></tr>");
-            sw2.Write("[td][b][i]DKP Net Change[/i][/b][/td][td][b][i]DKP Total[/i][/b][/td][td][/td][td][b][i]Tier[/i][/b][/td][td][b][i]Age[/i][/b][/td][/tr]");
+            sw.Write("<td width='15%'><b><i>DKP Net Change</b></i></td><td width='15%'><b><i>DKP Total</b></i><td width='15'></td><td width='*'><b><i>Tier</b></i></td><td width='10'><i><b>MIA</i></b></td></tr>");
+            sw2.Write("[td][b][i]DKP Net Change[/i][/b][/td][td][b][i]DKP Total[/i][/b][/td][td][/td][td][b][i]Tier[/i][/b][/td][td][b][i]MIA[/i][/b][/td][/tr]");
             owner.PBVal += 10;
             foreach (DataRow r in dtNT.Rows)
             {

--- a/Raid.cs
+++ b/Raid.cs
@@ -8,166 +8,166 @@ using System.Collections;
 
 namespace ES_DKP_Utils
 {
-	public class Raid
+    public class Raid
     {
 
         #region Declarations
         private frmMain owner;
 
-		private string _RaidName;
-		public string RaidName 
-		{
-			get { return _RaidName; }
-			set 
-			{
-				DataRow[] rs = dbRaid.Select("EventNameOrLoot='" + _RaidName + "' OR LootRaid='" + _RaidName + "'");
-				foreach (DataRow r in rs) 
-				{
-					if (r["EventNameOrLoot"].Equals(_RaidName)) 
-					{
-						r["EventNameOrLoot"] = value;
-					}
-					if (r["LootRaid"].Equals(_RaidName)) 
-					{
-						r["LootRaid"] = value;
-					}
-				}
-				_RaidName = value;
-			}
-		}
-		private DateTime _RaidDate;
-		public DateTime RaidDate
-		{
-			get { return _RaidDate; }
-			set 
-			{
-				DataRow[] rs = dbRaid.Select("Date =#" + _RaidDate.Month + "/" + _RaidDate.Day + "/" + _RaidDate.Year + "#");
-				foreach (DataRow r in rs) 
-				{
-					r["Date"] = value;
-				}
-				_RaidDate = value;
-			}
-		}
+        private string _RaidName;
+        public string RaidName
+        {
+            get { return _RaidName; }
+            set
+            {
+                DataRow[] rs = dbRaid.Select("EventNameOrLoot='" + _RaidName + "' OR LootRaid='" + _RaidName + "'");
+                foreach (DataRow r in rs)
+                {
+                    if (r["EventNameOrLoot"].Equals(_RaidName))
+                    {
+                        r["EventNameOrLoot"] = value;
+                    }
+                    if (r["LootRaid"].Equals(_RaidName))
+                    {
+                        r["LootRaid"] = value;
+                    }
+                }
+                _RaidName = value;
+            }
+        }
+        private DateTime _RaidDate;
+        public DateTime RaidDate
+        {
+            get { return _RaidDate; }
+            set
+            {
+                DataRow[] rs = dbRaid.Select("Date =#" + _RaidDate.Month + "/" + _RaidDate.Day + "/" + _RaidDate.Year + "#");
+                foreach (DataRow r in rs)
+                {
+                    r["Date"] = value;
+                }
+                _RaidDate = value;
+            }
+        }
         private bool _AttendanceSynced;
-		public bool AttendanceSynced
-		{
-			get
-			{
-				return _AttendanceSynced;
-			}
-			set
-			{
-				_AttendanceSynced = value;
-                
-			}
-		}
-		private bool _Loaded;
-		public bool Loaded
-		{
-			get
-			{
-				return _Loaded;
-			}
-			set
-			{
-				_Loaded = value;
-                
-			}
-		}
-		private bool _DoubleTier;
-		public bool DoubleTier
-		{
-			get
-			{
-				return _DoubleTier;
-			}
-			set
-			{
-				_DoubleTier = value;
-                
-			}
-		}
-		private System.Double _TotalDKP;
-		public System.Double TotalDKP
-		{
-			get
-			{
-				return _TotalDKP;
-			}
-			set
-			{
-				_TotalDKP = value;
-                
-			}
-		}
-		private int _Attendees;
-		public int Attendees
-		{
-			get
-			{
-				return _Attendees;
-			}
-			set
-			{
-				_Attendees = value;
-                
-			}
-		}
+        public bool AttendanceSynced
+        {
+            get
+            {
+                return _AttendanceSynced;
+            }
+            set
+            {
+                _AttendanceSynced = value;
 
-		private DataTable dbRaid;
-		private DataTable dbPeople;
-		private DataTable dbAlts;
+            }
+        }
+        private bool _Loaded;
+        public bool Loaded
+        {
+            get
+            {
+                return _Loaded;
+            }
+            set
+            {
+                _Loaded = value;
 
-		private OleDbConnection dbConnect;
-		private OleDbDataAdapter dkpDA;
-		private OleDbDataAdapter altDA;
-		private OleDbCommandBuilder cmdBld;
+            }
+        }
+        private bool _DoubleTier;
+        public bool DoubleTier
+        {
+            get
+            {
+                return _DoubleTier;
+            }
+            set
+            {
+                _DoubleTier = value;
+
+            }
+        }
+        private System.Double _TotalDKP;
+        public System.Double TotalDKP
+        {
+            get
+            {
+                return _TotalDKP;
+            }
+            set
+            {
+                _TotalDKP = value;
+
+            }
+        }
+        private int _Attendees;
+        public int Attendees
+        {
+            get
+            {
+                return _Attendees;
+            }
+            set
+            {
+                _Attendees = value;
+
+            }
+        }
+
+        private DataTable dbRaid;
+        private DataTable dbPeople;
+        private DataTable dbAlts;
+
+        private OleDbConnection dbConnect;
+        private OleDbDataAdapter dkpDA;
+        private OleDbDataAdapter altDA;
+        private OleDbCommandBuilder cmdBld;
         private OleDbCommandBuilder altBld;
 
-		private ArrayList ignore;
+        private ArrayList ignore;
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         #endregion
 
         #region Constuctor
         public Raid(frmMain owner)
-		{
+        {
             log.Debug("Begin Method: Raid.Raid(frmMain) (" + owner.ToString() + ")");
 
-			this.owner = owner;
-			this.ignore = new ArrayList();
-			DoubleTier = false;
-			string connectionStr;
-			connectionStr = "Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" + owner.DBString;
-			try { dbConnect = new OleDbConnection(connectionStr); }
-			catch (Exception ex) 
-			{
+            this.owner = owner;
+            this.ignore = new ArrayList();
+            DoubleTier = false;
+            string connectionStr;
+            connectionStr = "Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" + owner.DBString;
+            try { dbConnect = new OleDbConnection(connectionStr); }
+            catch (Exception ex)
+            {
                 log.Error("Failed to create data connection: " + ex.Message);
-				MessageBox.Show("Could not create data connection. \n(" + ex.Message + ")","Error");
-			}
-			dkpDA = new OleDbDataAdapter();
-			dbRaid = new DataTable("Raid");
-			dbRaid.Columns.Add("Name",System.Type.GetType("System.String"));
-			dbRaid.Columns.Add("Date",System.Type.GetType("System.DateTime"));
-			dbRaid.Columns.Add("EventNameOrLoot",System.Type.GetType("System.String"));
-			dbRaid.Columns.Add("PTS",System.Type.GetType("System.Double"));
-			dbRaid.Columns.Add("Comment",System.Type.GetType("System.String"));
-			dbRaid.Columns.Add("LootRaid",System.Type.GetType("System.String"));
+                MessageBox.Show("Could not create data connection. \n(" + ex.Message + ")", "Error");
+            }
+            dkpDA = new OleDbDataAdapter();
+            dbRaid = new DataTable("Raid");
+            dbRaid.Columns.Add("Name", System.Type.GetType("System.String"));
+            dbRaid.Columns.Add("Date", System.Type.GetType("System.DateTime"));
+            dbRaid.Columns.Add("EventNameOrLoot", System.Type.GetType("System.String"));
+            dbRaid.Columns.Add("PTS", System.Type.GetType("System.Double"));
+            dbRaid.Columns.Add("Comment", System.Type.GetType("System.String"));
+            dbRaid.Columns.Add("LootRaid", System.Type.GetType("System.String"));
 
-			dbPeople = new DataTable("People");
-			try 
-			{
-				string query = "SELECT DISTINCT Name FROM DKS WHERE (Name<>\"zzzDKP Retired\")";
-				dkpDA.SelectCommand = new OleDbCommand(query,dbConnect);
-				dbConnect.Open();
-				dkpDA.Fill(dbPeople);
-			}
-			catch (Exception ex) 
-			{
+            dbPeople = new DataTable("People");
+            try
+            {
+                string query = "SELECT DISTINCT Name FROM DKS WHERE (Name<>\"zzzDKP Retired\")";
+                dkpDA.SelectCommand = new OleDbCommand(query, dbConnect);
+                dbConnect.Open();
+                dkpDA.Fill(dbPeople);
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to load people table: " + ex.Message);
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbConnect.Close(); }
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbConnect.Close(); }
 
             log.Debug("End Method: Raid.Raid()");
         }
@@ -175,154 +175,154 @@ namespace ES_DKP_Utils
 
         #region Methods
         public void LoadRaid()
-		{
+        {
             log.Debug("Begin Method: Raid.LoadRaid()");
 
-			try
-			{
-				string query = "SELECT * FROM DKS WHERE (Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND (((EventNameOrLoot LIKE '" + RaidName + "%' AND LootRaid NOT LIKE '__%') OR LootRaid LIKE '" + RaidName + "%') AND EventNameOrLoot NOT LIKE '%1') )";
-				dkpDA.SelectCommand = new OleDbCommand(query,dbConnect);
-				dbConnect.Open();
-				dkpDA.Fill(dbRaid);
-				cmdBld = new OleDbCommandBuilder(dkpDA);
-				Loaded = true;
+            try
+            {
+                string query = "SELECT * FROM DKS WHERE (Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND (((EventNameOrLoot LIKE '" + RaidName + "%' AND LootRaid NOT LIKE '__%') OR LootRaid LIKE '" + RaidName + "%') AND EventNameOrLoot NOT LIKE '%1') )";
+                dkpDA.SelectCommand = new OleDbCommand(query, dbConnect);
+                dbConnect.Open();
+                dkpDA.Fill(dbRaid);
+                cmdBld = new OleDbCommandBuilder(dkpDA);
+                Loaded = true;
 
-				DataRow[] tiercheck =  dbRaid.Select("EventNameOrLoot LIKE '%0' OR LootRaid LIKE '%0'");
-				if (tiercheck.Length>0) 
-				{
-					DoubleTier = true;
-					foreach (DataRow r in tiercheck)
-					{
-						bool isloot = (double)r.ItemArray[3] < 0;
-						if (isloot) 
-						{
-							string s = (string) r.ItemArray[5];
-							s = s.TrimEnd(new char[] { '0' } );
-							r.ItemArray = new object[] { 
-														   r.ItemArray[0], r.ItemArray[1],
-														   r.ItemArray[2], r.ItemArray[3],
-														   r.ItemArray[4], s };
-						}
-						else 
-						{
-							string s = (string) r.ItemArray[2];
-							s = s.TrimEnd(new char[] { '0' } );
-							r.ItemArray = new object[] { 
-														   r.ItemArray[0], r.ItemArray[1],
-														   s, r.ItemArray[3],
-														   r.ItemArray[4], r.ItemArray[5] };
-						}
-					}
+                DataRow[] tiercheck = dbRaid.Select("EventNameOrLoot LIKE '%0' OR LootRaid LIKE '%0'");
+                if (tiercheck.Length > 0)
+                {
+                    DoubleTier = true;
+                    foreach (DataRow r in tiercheck)
+                    {
+                        bool isloot = (double)r.ItemArray[3] < 0;
+                        if (isloot)
+                        {
+                            string s = (string)r.ItemArray[5];
+                            s = s.TrimEnd(new char[] { '0' });
+                            r.ItemArray = new object[] {
+                                                           r.ItemArray[0], r.ItemArray[1],
+                                                           r.ItemArray[2], r.ItemArray[3],
+                                                           r.ItemArray[4], s };
+                        }
+                        else
+                        {
+                            string s = (string)r.ItemArray[2];
+                            s = s.TrimEnd(new char[] { '0' });
+                            r.ItemArray = new object[] {
+                                                           r.ItemArray[0], r.ItemArray[1],
+                                                           s, r.ItemArray[3],
+                                                           r.ItemArray[4], r.ItemArray[5] };
+                        }
+                    }
 
-				}
-			}
-			catch (Exception ex) 
-			{
+                }
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to load raid: " + ex.Message);
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbConnect.Close(); }
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbConnect.Close(); }
 
             log.Debug("End Method: Raid.LoadRaid()");
-		}
+        }
 
-		public void ShowAttendees()
-		{
+        public void ShowAttendees()
+        {
             log.Debug("Begin Method: Raid.ShowAttendees()");
 
-			DataRow[] attendees = dbRaid.Select("(PTS>=0)");
-			DataTable newTable = rowsToTable(dbRaid,attendees);
-			TableViewer table = new TableViewer(owner,newTable,new TableViewer.UpdateDel(UpdateAttendees));
-			table.Show();
+            DataRow[] attendees = dbRaid.Select("(PTS>=0)");
+            DataTable newTable = rowsToTable(dbRaid, attendees);
+            TableViewer table = new TableViewer(owner, newTable, new TableViewer.UpdateDel(UpdateAttendees));
+            table.Show();
 
             log.Debug("End Method: Raid.ShowAttendees()");
-		}
-		public void UpdateAttendees(DataTable dt) 
-		{
+        }
+        public void UpdateAttendees(DataTable dt)
+        {
             log.Debug("Begin Method: Raid.UpdateAttendees(DataTable) (" + dt.ToString() + ")");
 
-			foreach (DataRow r in dbRaid.Select("(PTS>=0)")) { dbRaid.Rows.Remove(r); }
-			foreach (DataRow r in dt.Rows) { dbRaid.Rows.Add(r.ItemArray); }			
+            foreach (DataRow r in dbRaid.Select("(PTS>=0)")) { dbRaid.Rows.Remove(r); }
+            foreach (DataRow r in dt.Rows) { dbRaid.Rows.Add(r.ItemArray); }
 
             log.Debug("End Method: Raid.UpdateAttendees()");
-		}
+        }
 
-		public void ShowLoot()
-		{
+        public void ShowLoot()
+        {
             log.Debug("Begin Method: Raid.ShowLoot()");
 
-			DataRow[] loot = dbRaid.Select("(PTS<0)");
-			DataTable newTable = rowsToTable(dbRaid,loot);
-			TableViewer table = new TableViewer(owner,newTable,new TableViewer.UpdateDel(UpdateLoot));
-			table.Show();
+            DataRow[] loot = dbRaid.Select("(PTS<0)");
+            DataTable newTable = rowsToTable(dbRaid, loot);
+            TableViewer table = new TableViewer(owner, newTable, new TableViewer.UpdateDel(UpdateLoot));
+            table.Show();
 
             log.Debug("End Method: Raid.ShowLoot()");
-		}
+        }
 
-		public void UpdateLoot(DataTable dt) 
-		{
+        public void UpdateLoot(DataTable dt)
+        {
             log.Debug("Begin Method: Raid.UpdateLoot(DataTable) (" + dt.ToString() + ")");
 
-			foreach (DataRow r in dbRaid.Select("(PTS<0)")) { dbRaid.Rows.Remove(r); }
-			foreach (DataRow r in dt.Rows) { dbRaid.Rows.Add(r.ItemArray); }
+            foreach (DataRow r in dbRaid.Select("(PTS<0)")) { dbRaid.Rows.Remove(r); }
+            foreach (DataRow r in dt.Rows) { dbRaid.Rows.Add(r.ItemArray); }
 
             log.Debug("End Method: Raid.UpdateLoot()");
-		}
+        }
 
-		public void InputPerson(string s)
-		{
+        public void InputPerson(string s)
+        {
             log.Debug("Begin Method: Raid.InputPerson(string) (" + s.ToString() + ")");
 
-			DataRow[] rows = dbPeople.Select("Name='" + s + "'");
+            DataRow[] rows = dbPeople.Select("Name='" + s + "'");
 
-			if (rows.Length > 0)
-			{
-				DataRow[] rs = dbRaid.Select("Name='" + s + "' AND PTS>=0");
+            if (rows.Length > 0)
+            {
+                DataRow[] rs = dbRaid.Select("Name='" + s + "' AND PTS>=0");
                 if (rs.Length == 0)
                 {
                     dbRaid.Rows.Add(new object[] { s, RaidDate, RaidName, 0, null, null });
                     log.Debug("Added person: " + s);
                 }
-			}
-			else
-			{
-				string t = GetAlt(s);
-				if ((t != null && t.Length != 0)) 
-				{ 
-					if (dbRaid.Select("Name='" + t + "' AND PTS>=0").Length==0) 
-					{
-						DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
+            }
+            else
+            {
+                string t = GetAlt(s);
+                if ((t != null && t.Length != 0))
+                {
+                    if (dbRaid.Select("Name='" + t + "' AND PTS>=0").Length == 0)
+                    {
+                        DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
                         if (rs.Length == 0)
                         {
                             dbRaid.Rows.Add(new object[] { t, RaidDate, RaidName, 0, null, null });
                             log.Debug("Added person: " + t);
                         }
 
-					}
-					
-				}
-				else 
-				{
-					if (!ignore.Contains(t)) 
-					{
-						AppAltDialog alt = new AppAltDialog(owner,s,dbPeople);
-						t = alt.GetName();
-						if ((t != null && t.Length != 0))
-						{ 
-							DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
-							if (rs.Length==0) 
-							{
-								dbRaid.Rows.Add(new object[] {t,RaidDate,RaidName,0,null,null});
+                    }
+
+                }
+                else
+                {
+                    if (!ignore.Contains(t))
+                    {
+                        AppAltDialog alt = new AppAltDialog(owner, s, dbPeople);
+                        t = alt.GetName();
+                        if ((t != null && t.Length != 0))
+                        {
+                            DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
+                            if (rs.Length == 0)
+                            {
+                                dbRaid.Rows.Add(new object[] { t, RaidDate, RaidName, 0, null, null });
                                 log.Debug("Added person: " + t);
-							}
-							if (t!=s) dbAlts.Rows.Add(new object[] {s,t});
-							altDA.Update(dbAlts);
-						} 
-						else { ignore.Add(t); }
-					}
-				}
-			}
-		}
+                            }
+                            if (t != s) dbAlts.Rows.Add(new object[] { s, t });
+                            altDA.Update(dbAlts);
+                        }
+                        else { ignore.Add(t); }
+                    }
+                }
+            }
+        }
 
         public void ParseRaidDump(string logFile)
         {
@@ -421,39 +421,39 @@ namespace ES_DKP_Utils
             log.Debug("End Method: Raid.ParseRaidDump()");
         }
 
-		public void ParseAttendance(string logFile, string zo) 
-		{
+        public void ParseAttendance(string logFile, string zo)
+        {
             log.Debug("Begin Method: Raid.ParseAttendance(string,string) (" + logFile.ToString() + "," + zo.ToString() + ")");
 
-			string[] zones = zo.Split(new char[] { ' ' });
-			string line;
-			FileStream input;
-			StreamReader sr;
+            string[] zones = zo.Split(new char[] { ' ' });
+            string line;
+            FileStream input;
+            StreamReader sr;
             Regex regex = new Regex(@"\[.*\] \[.*\] (?<name>\S+).*<(?<guild>.*)> ZONE: (?<zone>.*)$");
-			Match m;
-			ArrayList people = new ArrayList();
-		
-			foreach (DataRow z in dbRaid.Rows)	people.Add(z.ItemArray[0]);
+            Match m;
+            ArrayList people = new ArrayList();
 
-			try 
-			{ 
-				input = new FileStream(logFile,FileMode.Open,FileAccess.Read);
-				sr = new StreamReader(input);
-			}
-			catch (Exception ex) 
-			{
+            foreach (DataRow z in dbRaid.Rows) people.Add(z.ItemArray[0]);
+
+            try
+            {
+                input = new FileStream(logFile, FileMode.Open, FileAccess.Read);
+                sr = new StreamReader(input);
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to open log to parse: " + ex.Message);
-				MessageBox.Show("File IO Error.\n(" + ex.Message + ")");
-				return;
-			}
+                MessageBox.Show("File IO Error.\n(" + ex.Message + ")");
+                return;
+            }
 
-			do
-			{
-				line = sr.ReadLine();
-	
-				if (line!=null) 
-				{
-					m = regex.Match(line);
+            do
+            {
+                line = sr.ReadLine();
+
+                if (line != null)
+                {
+                    m = regex.Match(line);
                     if (m.Success)
                     {
                         string _guild = m.Groups["guild"].ToString();
@@ -464,88 +464,88 @@ namespace ES_DKP_Utils
                         {
                             log.Debug(_name + " <" + _guild + "> is in zone " + _zone + ", adding to people array.");
                             people.Add(_name);
-                        }        
+                        }
                     }
-				}
-			} while (line!=null);
+                }
+            } while (line != null);
 
-			sr.Close();
-			input.Close();
+            sr.Close();
+            input.Close();
 
-			people.Sort();
+            people.Sort();
 
-			foreach (string s in people)
-			{
-				DataRow[] rows = dbPeople.Select("Name='" + s + "'");
+            foreach (string s in people)
+            {
+                DataRow[] rows = dbPeople.Select("Name='" + s + "'");
 
-				if (rows.Length > 0)
-				{
-					DataRow[] rs = dbRaid.Select("Name='" + s + "' AND PTS>=0");
+                if (rows.Length > 0)
+                {
+                    DataRow[] rs = dbRaid.Select("Name='" + s + "' AND PTS>=0");
                     if (rs.Length == 0)
                     {
                         dbRaid.Rows.Add(new object[] { s, RaidDate, RaidName, 0, null, null });
                         log.Debug("Added attendance row for " + s);
                     }
-				}
-				else
-				{
-					string t = GetAlt(s);
-					if ((t != null && t.Length != 0)) 
-					{ 
-						if (!people.Contains(t)) 
-						{
-							DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
+                }
+                else
+                {
+                    string t = GetAlt(s);
+                    if ((t != null && t.Length != 0))
+                    {
+                        if (!people.Contains(t))
+                        {
+                            DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
                             if (rs.Length == 0)
                             {
                                 dbRaid.Rows.Add(new object[] { t, RaidDate, RaidName, 0, null, null });
                                 log.Debug("Added attendance row for " + t + " (Alt: " + s + ")");
                             }
-						}
-					
-					}
-					else 
-					{
-						AppAltDialog alt = new AppAltDialog(owner,s,dbPeople);
-						t = alt.GetName();
-						if ((t != null && t.Length != 0))
-						{ 
-							DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
-							if (rs.Length==0) 
-							{
-								dbRaid.Rows.Add(new object[] {t,RaidDate,RaidName,0,null,null});
-                                log.Debug("Added attendance row for " + t);
-							}
-							if (t!=s) dbAlts.Rows.Add(new object[] {s,t});
-							altDA.Update(dbAlts);
-						}
-					}
-				}
-					
-			}
-            log.Debug("Begin Method: Raid.ParseAttendance()");
-		}
+                        }
 
-		public string GetAlt(string s)
-		{
+                    }
+                    else
+                    {
+                        AppAltDialog alt = new AppAltDialog(owner, s, dbPeople);
+                        t = alt.GetName();
+                        if ((t != null && t.Length != 0))
+                        {
+                            DataRow[] rs = dbRaid.Select("Name='" + t + "' AND PTS>=0");
+                            if (rs.Length == 0)
+                            {
+                                dbRaid.Rows.Add(new object[] { t, RaidDate, RaidName, 0, null, null });
+                                log.Debug("Added attendance row for " + t);
+                            }
+                            if (t != s) dbAlts.Rows.Add(new object[] { s, t });
+                            altDA.Update(dbAlts);
+                        }
+                    }
+                }
+
+            }
+            log.Debug("Begin Method: Raid.ParseAttendance()");
+        }
+
+        public string GetAlt(string s)
+        {
             log.Debug("Begin Method: Raid.GetAlt(string) (" + s.ToString() + ")");
 
-			dbAlts = new DataTable("Alts");
-			string query = "SELECT * FROM ALTS";
-			try 
-			{
-				altDA = new OleDbDataAdapter(query,dbConnect);
-				dbConnect.Open();
-				altDA.Fill(dbAlts);
-				altBld = new OleDbCommandBuilder(altDA);
-			}
-			catch (Exception ex) 
-			{
+            dbAlts = new DataTable("Alts");
+            string query = "SELECT * FROM ALTS";
+            try
+            {
+                altDA = new OleDbDataAdapter(query, dbConnect);
+                dbConnect.Open();
+                altDA.Fill(dbAlts);
+                altBld = new OleDbCommandBuilder(altDA);
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to load alts table: " + ex.Message);
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbConnect.Close(); }
-			
-			DataRow[] rows = dbAlts.Select("AltName='" + s + "'");
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbConnect.Close(); }
+
+            DataRow[] rows = dbAlts.Select("AltName='" + s + "'");
 
             if (rows.Length > 0)
             {
@@ -554,12 +554,12 @@ namespace ES_DKP_Utils
             }
 
             log.Debug("End Method: Raid.GetAlt(), returning ");
-			return "";
+            return "";
 
-		}
+        }
 
-		public string[] ParseLine(string line)
-		{
+        public string[] ParseLine(string line)
+        {
             /* Whatever is using this function is expecting a string array to come back with these elements:
              *   0: Raider's Name
              *   1: Zone
@@ -571,16 +571,16 @@ namespace ES_DKP_Utils
             Regex r = new Regex(@"\[.*\] \[.*\] (?<name>\S+).*<(?<guild>.*)> ZONE: (?<zone>.*)$");
             Match m = r.Match(line.Trim());
 
-            string[] results = { m.Groups["name"].ToString(), 
+            string[] results = { m.Groups["name"].ToString(),
                                  m.Groups["zone"].ToString(),
                                  m.Groups["guild"].ToString() };
 
             log.Debug("End Method: Raid.ParseLine(), returning {" + results[0] + "," + results[1] + "}");
-			return results;
-		}
+            return results;
+        }
 
-		public void AddRowToLocalTable(object[] o)
-		{
+        public void AddRowToLocalTable(object[] o)
+        {
             log.Debug("Begin Method: Raid.AddRowToLocalTable(object[]) (" + o.ToString() + ")");
             string s = "Creating new row: ";
             try
@@ -593,294 +593,294 @@ namespace ES_DKP_Utils
                 }
                 log.Debug(s.TrimEnd(new char[] { ',' }));
             }
-            catch(Exception ex) {
+            catch (Exception ex) {
                 log.Error("Error adding row to local table: " + ex.Message);
             }
-            
 
-			DataRow r = dbRaid.NewRow();
-			r.ItemArray = o;
-			dbRaid.Rows.Add(r);
+
+            DataRow r = dbRaid.NewRow();
+            r.ItemArray = o;
+            dbRaid.Rows.Add(r);
 
             log.Debug("End Method: Raid.AddRowToLocalTable()");
-		}
+        }
 
-		public void DivideDKP()
-		{
+        public void DivideDKP()
+        {
             log.Debug("Begin Method: Raid.DivideDKP()");
 
-			double dkp = 0.0;
-			DataRow[] rows = dbRaid.Select("PTS<0 AND LootRaid='" + RaidName + "'");
-			foreach (DataRow r in rows) { dkp += Math.Abs((double)r.ItemArray[3]); }
+            double dkp = 0.0;
+            DataRow[] rows = dbRaid.Select("PTS<0 AND LootRaid='" + RaidName + "'");
+            foreach (DataRow r in rows) { dkp += Math.Abs((double)r.ItemArray[3]); }
             log.Info("Total dkp to distribute: " + dkp);
 
-			rows = dbRaid.Select("PTS>=0 AND EventNameOrLoot='" + RaidName + "'");
-			if (rows.Length==0) rows = dbRaid.Select("PTS>=0 AND EventNameOrLoot='" + RaidName + "0'");
-			if (rows.Length==0) return;
+            rows = dbRaid.Select("PTS>=0 AND EventNameOrLoot='" + RaidName + "'");
+            if (rows.Length == 0) rows = dbRaid.Select("PTS>=0 AND EventNameOrLoot='" + RaidName + "0'");
+            if (rows.Length == 0) return;
 
-			Attendees = rows.Length;
+            Attendees = rows.Length;
             log.Info("Total attendees: " + Attendees);
 
-			TotalDKP = dkp;
-			dkp *= (1 - owner.DKPTax);
-			dkp /= rows.Length;
+            TotalDKP = dkp;
+            dkp *= (1 - owner.DKPTax);
+            dkp /= rows.Length;
 
             log.Info("DKP per person: " + dkp);
 
-			foreach (DataRow r in rows) 
-			{
-				r.ItemArray = new object[] { r.ItemArray[0],r.ItemArray[1],r.ItemArray[2],dkp,r.ItemArray[4],r.ItemArray[5] };
-			}
+            foreach (DataRow r in rows)
+            {
+                r.ItemArray = new object[] { r.ItemArray[0], r.ItemArray[1], r.ItemArray[2], dkp, r.ItemArray[4], r.ItemArray[5] };
+            }
 
             log.Debug("End Method: Raid.DivideDKP()");
-		}
+        }
 
-		public void SyncData() 
-		{
+        public void SyncData()
+        {
             int k = 0;
             log.Debug("Begin Method: Raid.SyncData()");
 
             owner.StatusMessage = "Saving raid...";
             owner.PBMin = 0;
-            owner.PBMax = dbRaid.Rows.Count+1;
+            owner.PBMax = dbRaid.Rows.Count + 1;
             owner.PBVal = 0;
 
-			string query = "UPDATE DKS SET Comment='DeleteMe' WHERE Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND ( (EventNameOrLoot LIKE '" + RaidName + "%' AND PTS>=0)OR (LootRaid LIKE '" + RaidName + "%' AND PTS<0))";
-			OleDbCommand updateCommand = null;
-			OleDbCommand insertCommand  = null;
-			OleDbCommand deleteCommand = null;
-			try 
-			{
-				updateCommand = new OleDbCommand(query,dbConnect);
-				dbConnect.Open();
-				updateCommand.ExecuteNonQuery();
+            string query = "UPDATE DKS SET Comment='DeleteMe' WHERE Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND ( (EventNameOrLoot LIKE '" + RaidName + "%' AND PTS>=0)OR (LootRaid LIKE '" + RaidName + "%' AND PTS<0))";
+            OleDbCommand updateCommand = null;
+            OleDbCommand insertCommand = null;
+            OleDbCommand deleteCommand = null;
+            try
+            {
+                updateCommand = new OleDbCommand(query, dbConnect);
+                dbConnect.Open();
+                updateCommand.ExecuteNonQuery();
                 log.Info("Updated " + k + " rows, flagged for deletion in DKS");
 
-				query = "UPDATE EventLog SET DKPValue=-1 WHERE EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND ( EventName LIKE '" + RaidName + "%' )";
-				updateCommand = new OleDbCommand(query,dbConnect);
-				k = updateCommand.ExecuteNonQuery();
+                query = "UPDATE EventLog SET DKPValue=-1 WHERE EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND ( EventName LIKE '" + RaidName + "%' )";
+                updateCommand = new OleDbCommand(query, dbConnect);
+                k = updateCommand.ExecuteNonQuery();
                 log.Info("Updated " + k + " rows, flagged for deletion in EventLog");
-			}
-			catch (Exception ex) 
-			{
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to load either DKS or EventLog: " + ex.Message);
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbConnect.Close(); }
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbConnect.Close(); }
 
-			DataRow[] ppl = dbRaid.Select("PTS>=0");
-			DataRow[] loot = dbRaid.Select("PTS<0");
+            DataRow[] ppl = dbRaid.Select("PTS>=0");
+            DataRow[] loot = dbRaid.Select("PTS<0");
 
-			string lootstr;
+            string lootstr;
 
-			if (!DoubleTier) 
-			{
-				try 
-				{
-					dbConnect.Open();
-					foreach (DataRow r in ppl) 
-					{
-						query = "UPDATE DKS SET EventNameOrLoot=\"" + r.ItemArray[2] + "\", PTS=" + r.ItemArray[3] + ", Comment=\"" + r.ItemArray[4] + "\", LootRaid=\"" + r.ItemArray[5] + "\" WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS>=0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventNameOrLoot=\"" + RaidName + "\")";
-						updateCommand = new OleDbCommand(query,dbConnect);
-						if ((k = updateCommand.ExecuteNonQuery()) == 0) 
-						{
-							query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + r.ItemArray[2] + "\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
-							insertCommand = new OleDbCommand(query,dbConnect);
-							k = insertCommand.ExecuteNonQuery();
-						}
+            if (!DoubleTier)
+            {
+                try
+                {
+                    dbConnect.Open();
+                    foreach (DataRow r in ppl)
+                    {
+                        query = "UPDATE DKS SET EventNameOrLoot=\"" + r.ItemArray[2] + "\", PTS=" + r.ItemArray[3] + ", Comment=\"" + r.ItemArray[4] + "\", LootRaid=\"" + r.ItemArray[5] + "\" WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS>=0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventNameOrLoot=\"" + RaidName + "\")";
+                        updateCommand = new OleDbCommand(query, dbConnect);
+                        if ((k = updateCommand.ExecuteNonQuery()) == 0)
+                        {
+                            query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + r.ItemArray[2] + "\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
+                            insertCommand = new OleDbCommand(query, dbConnect);
+                            k = insertCommand.ExecuteNonQuery();
+                        }
                         owner.PBVal++;
-					}
-					foreach (DataRow r in loot)
-					{
-						lootstr = (string)r.ItemArray[2];
-						query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + lootstr + "\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
-						insertCommand = new OleDbCommand(query,dbConnect);
-						insertCommand.ExecuteNonQuery();
+                    }
+                    foreach (DataRow r in loot)
+                    {
+                        lootstr = (string)r.ItemArray[2];
+                        query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + lootstr + "\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
+                        insertCommand = new OleDbCommand(query, dbConnect);
+                        insertCommand.ExecuteNonQuery();
 
                         owner.PBVal++;
-					}
-					DataTable temp = new DataTable();
-					query = "SELECT EventName FROM EventLog WHERE EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName NOT LIKE '%1'";
-					OleDbDataAdapter tempda =  new OleDbDataAdapter(query,dbConnect);
-					tempda.Fill(temp);
+                    }
+                    DataTable temp = new DataTable();
+                    query = "SELECT EventName FROM EventLog WHERE EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName NOT LIKE '%1'";
+                    OleDbDataAdapter tempda = new OleDbDataAdapter(query, dbConnect);
+                    tempda.Fill(temp);
 
-					query = "UPDATE EventLog ";
-					query += "SET Points=" + (TotalDKP/Attendees)*(1-owner.DKPTax) + ", DKPValue=" + TotalDKP + " ";
-					query += "WHERE (EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName=\"" + RaidName + "\")";
+                    query = "UPDATE EventLog ";
+                    query += "SET Points=" + (TotalDKP / Attendees) * (1 - owner.DKPTax) + ", DKPValue=" + TotalDKP + " ";
+                    query += "WHERE (EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName=\"" + RaidName + "\")";
 
-					updateCommand = new OleDbCommand(query,dbConnect);
-					if (updateCommand.ExecuteNonQuery() == 0)
-					{
-						query = "INSERT INTO EventLog Values (#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + RaidName + "\"," + (TotalDKP/Attendees)*(1-owner.DKPTax) + "," + TotalDKP + "," + (int)((int)temp.Rows.Count + 1) + ")";
-						insertCommand = new OleDbCommand(query,dbConnect);
-						insertCommand.ExecuteNonQuery();
-					}
+                    updateCommand = new OleDbCommand(query, dbConnect);
+                    if (updateCommand.ExecuteNonQuery() == 0)
+                    {
+                        query = "INSERT INTO EventLog Values (#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + RaidName + "\"," + (TotalDKP / Attendees) * (1 - owner.DKPTax) + "," + TotalDKP + "," + (int)((int)temp.Rows.Count + 1) + ")";
+                        insertCommand = new OleDbCommand(query, dbConnect);
+                        insertCommand.ExecuteNonQuery();
+                    }
                     owner.PBVal++;
 
-					query = "DELETE FROM DKS WHERE Comment='DeleteMe'";
-					deleteCommand = new OleDbCommand(query,dbConnect);
-					deleteCommand.ExecuteNonQuery();
-					query = "DELETE FROM EventLog WHERE DKPValue=-1";
-					deleteCommand = new OleDbCommand(query,dbConnect);
-					deleteCommand.ExecuteNonQuery();
-				}
-				catch (Exception ex) 
-				{
+                    query = "DELETE FROM DKS WHERE Comment='DeleteMe'";
+                    deleteCommand = new OleDbCommand(query, dbConnect);
+                    deleteCommand.ExecuteNonQuery();
+                    query = "DELETE FROM EventLog WHERE DKPValue=-1";
+                    deleteCommand = new OleDbCommand(query, dbConnect);
+                    deleteCommand.ExecuteNonQuery();
+                }
+                catch (Exception ex)
+                {
                     log.Error("Failed to update DKS or EventLog: " + ex.Message);
-					MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-				}
-				finally { dbConnect.Close(); }
-			}
-			else
-			{
-				try 
-				{
-					dbConnect.Open();
-					foreach (DataRow r in ppl) 
-					{
-						query = "UPDATE DKS SET EventNameOrLoot=\"" + r.ItemArray[2] + "0\", PTS=" + r.ItemArray[3] + ", Comment=\"" + r.ItemArray[4] + "\", LootRaid=\"" + r.ItemArray[5] + "\" WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS>=0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventNameOrLoot=\"" + RaidName + "0\")";
-						updateCommand = new OleDbCommand(query,dbConnect);
-						if (updateCommand.ExecuteNonQuery() == 0) 
-						{
-							query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + r.ItemArray[2] + "0\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
-							insertCommand = new OleDbCommand(query,dbConnect);
-							insertCommand.ExecuteNonQuery();
-						}
+                    MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+                }
+                finally { dbConnect.Close(); }
+            }
+            else
+            {
+                try
+                {
+                    dbConnect.Open();
+                    foreach (DataRow r in ppl)
+                    {
+                        query = "UPDATE DKS SET EventNameOrLoot=\"" + r.ItemArray[2] + "0\", PTS=" + r.ItemArray[3] + ", Comment=\"" + r.ItemArray[4] + "\", LootRaid=\"" + r.ItemArray[5] + "\" WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS>=0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventNameOrLoot=\"" + RaidName + "0\")";
+                        updateCommand = new OleDbCommand(query, dbConnect);
+                        if (updateCommand.ExecuteNonQuery() == 0)
+                        {
+                            query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + r.ItemArray[2] + "0\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
+                            insertCommand = new OleDbCommand(query, dbConnect);
+                            insertCommand.ExecuteNonQuery();
+                        }
 
-						query = "UPDATE DKS SET EventNameOrLoot=\"" + r.ItemArray[2] + "1\", PTS=0, Comment=\"" + r.ItemArray[4] + "\", LootRaid=\"" + r.ItemArray[5] + "\" WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS>=0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventNameOrLoot=\"" + RaidName + "1\")";
-						updateCommand = new OleDbCommand(query,dbConnect);
-						if (updateCommand.ExecuteNonQuery() == 0) 
-						{
-							query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + r.ItemArray[2] + "1\",0,\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
-							insertCommand = new OleDbCommand(query,dbConnect);
-							insertCommand.ExecuteNonQuery();
-						}
-
-                        owner.PBVal++;
-					}
-					foreach (DataRow r in loot)
-					{
-						lootstr = (string)r.ItemArray[2];
-						query = "UPDATE DKS ";
-						query += "SET PTS=" + r.ItemArray[3] + ", Comment=\"" + r.ItemArray[4] + "\" ";
-						query += "WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS<0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND LootRaid=\"" + RaidName + "0\" AND EventNameOrLoot=\"" + lootstr + "\")";
-						updateCommand = new OleDbCommand(query,dbConnect);
-
-						if (updateCommand.ExecuteNonQuery() == 0) 
-						{
-							query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + lootstr + "\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "0\")";
-							insertCommand = new OleDbCommand(query,dbConnect);
-							insertCommand.ExecuteNonQuery();
-						}
+                        query = "UPDATE DKS SET EventNameOrLoot=\"" + r.ItemArray[2] + "1\", PTS=0, Comment=\"" + r.ItemArray[4] + "\", LootRaid=\"" + r.ItemArray[5] + "\" WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS>=0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventNameOrLoot=\"" + RaidName + "1\")";
+                        updateCommand = new OleDbCommand(query, dbConnect);
+                        if (updateCommand.ExecuteNonQuery() == 0)
+                        {
+                            query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + r.ItemArray[2] + "1\",0,\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "\")";
+                            insertCommand = new OleDbCommand(query, dbConnect);
+                            insertCommand.ExecuteNonQuery();
+                        }
 
                         owner.PBVal++;
-					}
-					DataTable temp = new DataTable();
-					query = "SELECT EventName FROM EventLog WHERE EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName NOT LIKE '%1'";
-					OleDbDataAdapter tempda =  new OleDbDataAdapter(query,dbConnect);
-					tempda.Fill(temp);
+                    }
+                    foreach (DataRow r in loot)
+                    {
+                        lootstr = (string)r.ItemArray[2];
+                        query = "UPDATE DKS ";
+                        query += "SET PTS=" + r.ItemArray[3] + ", Comment=\"" + r.ItemArray[4] + "\" ";
+                        query += "WHERE (Name=\"" + r.ItemArray[0] + "\" AND PTS<0 AND Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND LootRaid=\"" + RaidName + "0\" AND EventNameOrLoot=\"" + lootstr + "\")";
+                        updateCommand = new OleDbCommand(query, dbConnect);
 
-					query = "UPDATE EventLog ";
-					query += "SET Points=" + (TotalDKP/Attendees)*(1-owner.DKPTax) + ", DKPValue=" + TotalDKP + " ";
-					query += "WHERE (EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName=\"" + RaidName + "0\")";
+                        if (updateCommand.ExecuteNonQuery() == 0)
+                        {
+                            query = "INSERT INTO DKS VALUES (\"" + r.ItemArray[0] + "\",#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + lootstr + "\"," + r.ItemArray[3] + ",\"" + r.ItemArray[4] + "\",\"" + r.ItemArray[5] + "0\")";
+                            insertCommand = new OleDbCommand(query, dbConnect);
+                            insertCommand.ExecuteNonQuery();
+                        }
 
-					updateCommand = new OleDbCommand(query,dbConnect);
-					if (updateCommand.ExecuteNonQuery() == 0)
-					{
-						query = "INSERT INTO EventLog Values (#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + RaidName + "0\"," + (TotalDKP/Attendees)*(1-owner.DKPTax) + "," + TotalDKP + "," + (int)((int)temp.Rows.Count + 1) + ")";
-						insertCommand = new OleDbCommand(query,dbConnect);
-						insertCommand.ExecuteNonQuery();
-					}
+                        owner.PBVal++;
+                    }
+                    DataTable temp = new DataTable();
+                    query = "SELECT EventName FROM EventLog WHERE EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName NOT LIKE '%1'";
+                    OleDbDataAdapter tempda = new OleDbDataAdapter(query, dbConnect);
+                    tempda.Fill(temp);
 
-					query = "UPDATE EventLog ";
-					query += "SET Points=0, DKPValue=0 ";
-					query += "WHERE (EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName=\"" + RaidName + "1\")";
+                    query = "UPDATE EventLog ";
+                    query += "SET Points=" + (TotalDKP / Attendees) * (1 - owner.DKPTax) + ", DKPValue=" + TotalDKP + " ";
+                    query += "WHERE (EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName=\"" + RaidName + "0\")";
 
-					updateCommand = new OleDbCommand(query,dbConnect);
-					if (updateCommand.ExecuteNonQuery() == 0)
-					{
-						query = "INSERT INTO EventLog Values (#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + RaidName + "1\"," + 0 + "," + 0 + "," + (int)((int)temp.Rows.Count + 1) + ")";
-						insertCommand = new OleDbCommand(query,dbConnect);
-						insertCommand.ExecuteNonQuery();
-					}
+                    updateCommand = new OleDbCommand(query, dbConnect);
+                    if (updateCommand.ExecuteNonQuery() == 0)
+                    {
+                        query = "INSERT INTO EventLog Values (#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + RaidName + "0\"," + (TotalDKP / Attendees) * (1 - owner.DKPTax) + "," + TotalDKP + "," + (int)((int)temp.Rows.Count + 1) + ")";
+                        insertCommand = new OleDbCommand(query, dbConnect);
+                        insertCommand.ExecuteNonQuery();
+                    }
+
+                    query = "UPDATE EventLog ";
+                    query += "SET Points=0, DKPValue=0 ";
+                    query += "WHERE (EventDate=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND EventName=\"" + RaidName + "1\")";
+
+                    updateCommand = new OleDbCommand(query, dbConnect);
+                    if (updateCommand.ExecuteNonQuery() == 0)
+                    {
+                        query = "INSERT INTO EventLog Values (#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "#,\"" + RaidName + "1\"," + 0 + "," + 0 + "," + (int)((int)temp.Rows.Count + 1) + ")";
+                        insertCommand = new OleDbCommand(query, dbConnect);
+                        insertCommand.ExecuteNonQuery();
+                    }
 
                     owner.PBVal++;
 
-					query = "DELETE FROM DKS WHERE Comment='DeleteMe'";
-					deleteCommand = new OleDbCommand(query,dbConnect);
-					deleteCommand.ExecuteNonQuery();
-					query = "DELETE FROM EventLog WHERE DKPValue=-1";
-					deleteCommand = new OleDbCommand(query,dbConnect);
-					deleteCommand.ExecuteNonQuery();
-				}				
-				catch (Exception ex) 
-				{
+                    query = "DELETE FROM DKS WHERE Comment='DeleteMe'";
+                    deleteCommand = new OleDbCommand(query, dbConnect);
+                    deleteCommand.ExecuteNonQuery();
+                    query = "DELETE FROM EventLog WHERE DKPValue=-1";
+                    deleteCommand = new OleDbCommand(query, dbConnect);
+                    deleteCommand.ExecuteNonQuery();
+                }
+                catch (Exception ex)
+                {
                     log.Error("Failed to update DKS or EventLog: " + ex.Message);
-					MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-				}
-				finally { dbConnect.Close(); }
-			}
+                    MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+                }
+                finally { dbConnect.Close(); }
+            }
 
             log.Debug("End Method: Raid.SyncRaid()");
-		}
+        }
 
-		public void FigureTiers()
-		{
+        public void FigureTiers()
+        {
             log.Debug("Begin Method: Raid.FigureTiers()");
 
-			string query = "SELECT DISTINCT EventDate FROM EventLog WHERE EventDate <= #" + DateTime.Now.Month + "/" + DateTime.Now.Day + "/" + DateTime.Now.Year + "#";
-			DataTable dates = null;
-			DataTable nameCount = null;
-			try
-			{
-				dates = new DataTable("Date");
-				dkpDA = new OleDbDataAdapter(query,dbConnect);
-				dbConnect.Open();
-				dkpDA.Fill(dates);
-			}
-			catch (Exception ex) 
-			{
+            string query = "SELECT DISTINCT EventDate FROM EventLog WHERE EventDate <= #" + DateTime.Now.Month + "/" + DateTime.Now.Day + "/" + DateTime.Now.Year + "#";
+            DataTable dates = null;
+            DataTable nameCount = null;
+            try
+            {
+                dates = new DataTable("Date");
+                dkpDA = new OleDbDataAdapter(query, dbConnect);
+                dbConnect.Open();
+                dkpDA.Fill(dates);
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to fill dates table: " + ex.Message);
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbConnect.Close(); }
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbConnect.Close(); }
 
-			DateTime tierwindow = (DateTime) dates.Rows[dates.Rows.Count - 20].ItemArray[0];
-			int totalraids = 0;
-			try
-			{
-				OleDbCommand deleteCmd = new OleDbCommand("DELETE * FROM NamesTiers",dbConnect);
-				dbConnect.Open();
-				deleteCmd.ExecuteNonQuery();
-				nameCount = new DataTable("DKS");
-				query = "SELECT DKS.Name, Count(DKS.Name) as NameCount FROM DKS WHERE DKS.Date>=#" + tierwindow.Month + "/" + tierwindow.Day + "/" + tierwindow.Year + "# AND DKS.PTS>=0 GROUP BY DKS.Name";
-				dkpDA = new OleDbDataAdapter(query,dbConnect);
-				dkpDA.Fill(nameCount);
-				query = "SELECT Count(EventLog.EventName) as TotalRaids FROM EventLog WHERE EventLog.EventDate>=#" + tierwindow.Month + "/" + tierwindow.Day + "/" + tierwindow.Year + "#";
-				dkpDA = new OleDbDataAdapter(query,dbConnect);
-				DataTable t = new DataTable("temp");
-				dkpDA.Fill(t);
-				totalraids = (int)t.Rows[0].ItemArray[0];
-			}
-			catch (Exception ex) 
-			{
+            DateTime tierwindow = (DateTime)dates.Rows[dates.Rows.Count - 20].ItemArray[0];
+            int totalraids = 0;
+            try
+            {
+                OleDbCommand deleteCmd = new OleDbCommand("DELETE * FROM NamesTiers", dbConnect);
+                dbConnect.Open();
+                deleteCmd.ExecuteNonQuery();
+                nameCount = new DataTable("DKS");
+                query = "SELECT DKS.Name, Count(DKS.Name) as NameCount FROM DKS WHERE DKS.Date>=#" + tierwindow.Month + "/" + tierwindow.Day + "/" + tierwindow.Year + "# AND DKS.PTS>=0 GROUP BY DKS.Name";
+                dkpDA = new OleDbDataAdapter(query, dbConnect);
+                dkpDA.Fill(nameCount);
+                query = "SELECT Count(EventLog.EventName) as TotalRaids FROM EventLog WHERE EventLog.EventDate>=#" + tierwindow.Month + "/" + tierwindow.Day + "/" + tierwindow.Year + "#";
+                dkpDA = new OleDbDataAdapter(query, dbConnect);
+                DataTable t = new DataTable("temp");
+                dkpDA.Fill(t);
+                totalraids = (int)t.Rows[0].ItemArray[0];
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to fill attendance count or raid count table: " + ex.Message);
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbConnect.Close(); }
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbConnect.Close(); }
 
             owner.PBMin = 0;
             owner.PBMax = nameCount.Rows.Count + nameCount.Rows.Count / 10;
             owner.PBVal = nameCount.Rows.Count / 10;
 
-			DataRow[] rows = nameCount.Select("Name<>'zzzDKP Retired'");
-			foreach (DataRow r in rows)
-			{
-				int numraids = (int) r.ItemArray[1];
-				char c;
-				double d;
-				string q;
-				d = (double) numraids/totalraids;
+            DataRow[] rows = nameCount.Select("Name<>'zzzDKP Retired'");
+            foreach (DataRow r in rows)
+            {
+                int numraids = (int)r.ItemArray[1];
+                char c;
+                double d;
+                string q;
+                d = (double)numraids / totalraids;
                 if (d >= owner.TierAPct)
                     c = 'A';
                 else if (d >= owner.TierBPct)
@@ -889,66 +889,66 @@ namespace ES_DKP_Utils
                     c = 'C';
                 else
                     c = 'E';
-				q = "INSERT INTO NamesTiers VALUES (\"" + r.ItemArray[0] + "\",\"" + c + "\"," + numraids + "," + d * 100 + ")";
-				try
-				{
-					OleDbCommand dbc = new OleDbCommand(q,dbConnect);
-					dbConnect.Open();
-					dbc.ExecuteNonQuery();
+                q = "INSERT INTO NamesTiers VALUES (\"" + r.ItemArray[0] + "\",\"" + c + "\"," + numraids + "," + d * 100 + ")";
+                try
+                {
+                    OleDbCommand dbc = new OleDbCommand(q, dbConnect);
+                    dbConnect.Open();
+                    dbc.ExecuteNonQuery();
                     owner.PBVal++;
-				}
-				catch (Exception ex) 
-				{
+                }
+                catch (Exception ex)
+                {
                     log.Error("Failed to write NamesTiers row: " + ex.Message);
-					MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-				}
-				finally { dbConnect.Close(); }
+                    MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+                }
+                finally { dbConnect.Close(); }
 
-			}
+            }
 
             log.Debug("End Method: Raid.FigureTiers()");
-		}
+        }
 
-		public void AddNameClass(string s, string t)
-		{
+        public void AddNameClass(string s, string t)
+        {
             log.Debug("Begin Method: Raid.AddNameClass(string,string) (" + s.ToString() + "," + t.ToString() + ")");
 
-			string query = "INSERT INTO NamesClassesRemix VALUES ('" + s + "','" + t + "')";
-			try
-			{
-				OleDbCommand nameclass = new OleDbCommand(query,dbConnect);
-				dbConnect.Open();
-				nameclass.ExecuteNonQuery();
-			}
-			catch (Exception ex) 
-			{
+            string query = "INSERT INTO NamesClassesRemix VALUES ('" + s + "','" + t + "')";
+            try
+            {
+                OleDbCommand nameclass = new OleDbCommand(query, dbConnect);
+                dbConnect.Open();
+                nameclass.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
                 log.Error("Failed to insert NamesClasses row: " + ex.Message);
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbConnect.Close(); }
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbConnect.Close(); }
 
             log.Debug("End Method: Raid.AddNameClass()");
-		}
+        }
 
-		public void AddPerson(string s)
-		{
+        public void AddPerson(string s)
+        {
             log.Debug("Begin Method: Raid.AddPerson(string) (" + s.ToString() + ")");
 
-			if (Present().Select("Name='" + s + "' AND PTS>=0").Length==0) 
-			{
-				object[] o = new object[] { s, RaidDate, RaidName, 0, "", "" };
-				AddRowToLocalTable(o);
-				DivideDKP();
-			}
+            if (Present().Select("Name='" + s + "' AND PTS>=0").Length == 0)
+            {
+                object[] o = new object[] { s, RaidDate, RaidName, 0, "", "" };
+                AddRowToLocalTable(o);
+                DivideDKP();
+            }
 
             log.Debug("End Method: Raid.AddPerson()");
-		}
+        }
 
-		public void RemovePerson(string s)
-		{
+        public void RemovePerson(string s)
+        {
             log.Debug("Begin Method: Raid.RemovePerson(string) (" + s.ToString() + ")");
 
-			DataRow[] rows = dbRaid.Select("Name='" + s + "' AND PTS>=0");
+            DataRow[] rows = dbRaid.Select("Name='" + s + "' AND PTS>=0");
             try { dbRaid.Rows.Remove(rows[0]); }
             catch (Exception ex)
             {
@@ -957,227 +957,231 @@ namespace ES_DKP_Utils
             DivideDKP();
 
             log.Debug("End Method: Raid.RemovePerson()");
-		}
+        }
 
-		public DataTable NotPresent()
-		{
+        public DataTable NotPresent()
+        {
             log.Debug("Begin Method: Raid.NotPresent()");
 
-			DataTable p = dbPeople.Copy();
-			DataRow[] deleteMe = new DataRow[p.Rows.Count];
-			int i = 0;
-			int j = 0;
-			foreach (DataRow r in p.Rows)
-			{
-				if (dbRaid.Select("Name='" + r.ItemArray[0] + "'").Length>0)
-				{
-					deleteMe[i] = r;
-					i++;
-				}
-			}
+            DataTable p = dbPeople.Copy();
+            DataRow[] deleteMe = new DataRow[p.Rows.Count];
+            int i = 0;
+            int j = 0;
+            foreach (DataRow r in p.Rows)
+            {
+                if (dbRaid.Select("Name='" + r.ItemArray[0] + "'").Length > 0)
+                {
+                    deleteMe[i] = r;
+                    i++;
+                }
+            }
 
-			for (j=0; j<i; j++) p.Rows.Remove(deleteMe[j]);
+            for (j = 0; j < i; j++) p.Rows.Remove(deleteMe[j]);
 
             log.Debug("End Method: Raid.NotPresent(), returning " + p.ToString());
-			return p;
-		}
+            return p;
+        }
 
-		public DataTable Present()
-		{
+        public DataTable Present()
+        {
             log.Debug("Begin Method: Raid.Present()");
 
-			DataTable p = dbRaid.Copy();
+            DataTable p = dbRaid.Copy();
 
             log.Debug("End Method: Raid.Present(),  returning " + p);
-			return p;
-		}
+            return p;
+        }
 
-		public static DataTable rowsToTable(DataTable baseTable, DataRow[] rows)
-		{
-			DataTable t = baseTable.Clone();
-			foreach (DataRow r in rows)
-			{
-				t.ImportRow(r);
-			}
-			return t;
-		}
+        public static DataTable rowsToTable(DataTable baseTable, DataRow[] rows)
+        {
+            DataTable t = baseTable.Clone();
+            foreach (DataRow r in rows)
+            {
+                t.ImportRow(r);
+            }
+            return t;
+        }
 
-		public static void DailyReport(frmMain owner, DateTime t)
-		{
-			OleDbConnection dbCon = null;
-			DataTable dtTotal = new DataTable("DKSALL");
-			DataTable dtDKS = new DataTable("DKS");
-			DataTable dtEL = new DataTable("EventLog");
-			DataTable dtNT = new DataTable("NamesTiers");
-			DataTable dtAllEvents = new DataTable("NTALL");
-			DataTable dtFinal = new DataTable("FINAL");
+        public static void DailyReport(frmMain owner, DateTime t)
+        {
+            OleDbConnection dbCon = null;
+            DataTable dtTotal = new DataTable("DKSALL");
+            DataTable dtDKS = new DataTable("DKS");
+            DataTable dtEL = new DataTable("EventLog");
+            DataTable dtNT = new DataTable("NamesTiers");
+            DataTable dtAllEvents = new DataTable("NTALL");
+            DataTable dtFinal = new DataTable("FINAL");
 
-			FileStream fs = null;
+            FileStream fs = null;
             FileStream fs2 = null;
-			StreamWriter sw = null;
+            StreamWriter sw = null;
             StreamWriter sw2 = null;
-			int i = 1;
-			double dkp = 0.0;
-			int ppl = 1;
-			bool twotier = false;
-			double earned;
-			double totalnetchange = 0.0;
-			double totaldkp = 0.0;
+            int i = 1;
+            double dkp = 0.0;
+            int ppl = 1;
+            bool twotier = false;
+            double earned;
+            double totalnetchange = 0.0;
+            double totaldkp = 0.0;
 
             owner.PBMin = 0;
             owner.PBMax = 110;
             owner.PBVal = 0;
-            
-			string connectionStr = "Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" + owner.DBString;
-			try { dbCon = new OleDbConnection(connectionStr); }
-			catch (Exception ex) 
-			{
-				MessageBox.Show("Could not create data connection. \n(" + ex.Message + ")","Error");
-			}
 
-			string query = "SELECT * FROM DKS WHERE Date=#" + t.Month + "/" + t.Day + "/" + t.Year + "# ORDER BY Name";
-			try
-			{
-				OleDbDataAdapter da = new OleDbDataAdapter(query,dbCon);
-				dbCon.Open();
-				da.Fill(dtDKS);
-				query = "SELECT * FROM EventLog WHERE EventDate=#" + t.Month + "/" + t.Day + "/" + t.Year + "# ORDER BY RaidNumber ASC";
-				da = new OleDbDataAdapter(query,dbCon);
-				da.Fill(dtEL);
-                owner.PBVal += 10;
-				query = "SELECT * FROM NamesTiers";
-				da = new OleDbDataAdapter(query,dbCon);
-				da.Fill(dtNT);
-                owner.PBVal += 10;
-				query = "SELECT Name, Sum(PTS) AS Total FROM DKS GROUP BY Name HAVING Name<>'zzzDKP Retired'";
-				da = new OleDbDataAdapter(query,dbCon);
-				da.Fill(dtTotal);
-                owner.PBVal += 10;
-				DataTable temp = new DataTable();
-				query = "SELECT DISTINCT EventDate FROM EventLog ORDER BY EventDate DESC";
-				da = new OleDbDataAdapter(query,dbCon);
-				da.Fill(temp);
-                owner.PBVal += 10;
-				DateTime tempdate = (DateTime)temp.Rows[19]["EventDate"];
-				query = "SELECT * FROM EventLog WHERE EventDate>=#" + tempdate.Month + "/" + tempdate.Day + "/" + tempdate.Year + "# ORDER BY EventDate ASC, RaidNumber ASC";
-				da = new OleDbDataAdapter(query,dbCon);
-				da.Fill(dtAllEvents);
-                owner.PBVal += 10;
-				query = "SELECT DKS.Name, Sum(DKS.PTS) AS Total, NamesTiers.Tier, NamesTiers.NumRaids, NamesTiers.TPercent ";
-				query += "FROM DKS INNER JOIN NamesTiers ON DKS.Name=NamesTiers.Name GROUP BY DKS.Name, NamesTiers.Tier, NamesTiers.TPercent, NamesTiers.NumRaids";
-				da = new OleDbDataAdapter(query,dbCon);
-				da.Fill(dtFinal);
-                owner.PBVal += 10;
-			}
-			catch (Exception ex) 
-			{
-				MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")","Error");
-			}
-			finally { dbCon.Close(); }
+            string connectionStr = "Provider=Microsoft.Jet.OLEDB.4.0;Data Source=" + owner.DBString;
+            try { dbCon = new OleDbConnection(connectionStr); }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Could not create data connection. \n(" + ex.Message + ")", "Error");
+            }
 
-			try 
-			{
+            try
+            {
+                string query = "SELECT * FROM DKS WHERE Date=#" + t.Month + "/" + t.Day + "/" + t.Year + "# ORDER BY Name";
+                OleDbDataAdapter da = new OleDbDataAdapter(query, dbCon);
+                dbCon.Open();
+                da.Fill(dtDKS);
+                query = "SELECT * FROM EventLog WHERE EventDate=#" + t.Month + "/" + t.Day + "/" + t.Year + "# ORDER BY RaidNumber ASC";
+                da = new OleDbDataAdapter(query, dbCon);
+                da.Fill(dtEL);
+                owner.PBVal += 10;
+                query = "SELECT * FROM NamesTiers";
+                da = new OleDbDataAdapter(query, dbCon);
+                da.Fill(dtNT);
+                owner.PBVal += 10;
+                query = "SELECT Name, Sum(PTS) AS Total FROM DKS GROUP BY Name HAVING Name<>'zzzDKP Retired'";
+                da = new OleDbDataAdapter(query, dbCon);
+                da.Fill(dtTotal);
+                owner.PBVal += 10;
+                DataTable temp = new DataTable();
+                query = "SELECT DISTINCT TOP " + owner.RaidDaysWindow + " EventDate FROM EventLog ORDER BY EventDate DESC";
+                da = new OleDbDataAdapter(query, dbCon);
+                da.Fill(temp);
+                owner.PBVal += 10;
+                DateTime tempdate = (DateTime)temp.Rows[owner.RaidDaysWindow - 1]["EventDate"];
+                query = "SELECT * FROM EventLog WHERE EventDate>=#" + tempdate.Month + "/" + tempdate.Day + "/" + tempdate.Year + "# ORDER BY EventDate ASC, RaidNumber ASC";
+                da = new OleDbDataAdapter(query, dbCon);
+                da.Fill(dtAllEvents);
+                owner.PBVal += 10;
+                query = "SELECT DKS.Name, Sum(DKS.PTS) AS Total, Max(DKS.Date) AS LastRaid, NamesTiers.Tier, NamesTiers.NumRaids, NamesTiers.TPercent ";
+                query += "FROM DKS INNER JOIN NamesTiers ON DKS.Name=NamesTiers.Name GROUP BY DKS.Name, NamesTiers.Tier, NamesTiers.TPercent, NamesTiers.NumRaids";
+                da = new OleDbDataAdapter(query, dbCon);
+                da.Fill(dtFinal);
+                owner.PBVal += 10;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
+            }
+            finally { dbCon.Close(); }
+
+            try
+            {
                 // Terrible hack while I convert to BBCode output
-				fs = new FileStream(owner.OutputDirectory + "DKPReport.txt",FileMode.Create);
-				sw = new StreamWriter(fs);
+                fs = new FileStream(owner.OutputDirectory + "DKPReport.txt", FileMode.Create);
+                sw = new StreamWriter(fs);
                 fs2 = new FileStream(owner.OutputDirectory + "DKPReport-bbcode.txt", FileMode.Create);
                 sw2 = new StreamWriter(fs2);
-			}
-			catch (Exception ex) 
-			{
-				MessageBox.Show("File IO Error. \n(" + ex.Message + ")","Error");
-			}
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("File IO Error. \n(" + ex.Message + ")", "Error");
+            }
 
             // Events + Loot table
-			sw.Write("<table width ='100%' border='1' cellspacing='0' cellpadding='3' bordercolor='#0000ff' bordercolorlight='#000000' bordercolordark='#ffffff' frame='border' rules='all' class='gensmall'>");
-			sw.Write("<tr><td colspan='4' bgcolor='black'><b>Events and Loot</b></td></tr>");
+            sw.Write("<table width ='100%' border='1' cellspacing='0' cellpadding='3' bordercolor='#0000ff' bordercolorlight='#000000' bordercolordark='#ffffff' frame='border' rules='all' class='gensmall'>");
+            sw.Write("<tr><td colspan='4' bgcolor='black'><b>Events and Loot</b></td></tr>");
             sw2.Write("[p][table][tr][th][b]Events and Loot[/b][/th][/tr]");
-			foreach (DataRow ev in dtEL.Select("EventName NOT LIKE '%1'","RaidNumber ASC"))
-			{
-				dkp=0;
-				twotier=false;
-				ppl = dtDKS.Select("EventNameOrLoot='" + ev["EventName"] + "'").Length;
-				string evstr = (string)ev["EventName"];
-				if (Regex.IsMatch(evstr,".*?0")) 
-				{
-					evstr = evstr.TrimEnd(new char[] { '0' });
-					twotier = true;
-				}
-				sw.Write("<tr><td colspan='4' bgcolor='black'><b>" + i + ".</b> " + evstr);
+            foreach (DataRow ev in dtEL.Select("EventName NOT LIKE '%1'", "RaidNumber ASC"))
+            {
+                dkp = 0;
+                twotier = false;
+                ppl = dtDKS.Select("EventNameOrLoot='" + ev["EventName"] + "'").Length;
+                string evstr = (string)ev["EventName"];
+                if (Regex.IsMatch(evstr, ".*?0"))
+                {
+                    evstr = evstr.TrimEnd(new char[] { '0' });
+                    twotier = true;
+                }
+                sw.Write("<tr><td colspan='4' bgcolor='black'><b>" + i + ".</b> " + evstr);
                 sw2.Write("[tr][th][b]" + i + ".[/b] " + evstr);
                 if (twotier)
                 {
                     sw.Write("<b><i> Double Tier</b></i>");
                     sw2.Write("[b][i] Double Tier[/b][/i]");
                 }
-				sw.Write("</td></tr>");
+                sw.Write("</td></tr>");
                 sw2.Write("[/th][/tr]");
-				sw.Write("<tr><td width='30%'><i><b>Loot</b></i></td><td width='25%'><b><i>Recipient</b></i></td><td width='15%'><b><i>Cost</b></i></td><td width='30%'><b><i>DKP Per Person</b></i></td></tr>");
+                sw.Write("<tr><td width='30%'><i><b>Loot</b></i></td><td width='25%'><b><i>Recipient</b></i></td><td width='15%'><b><i>Cost</b></i></td><td width='30%'><b><i>DKP Per Person</b></i></td></tr>");
                 sw2.Write("[tr][td][i][b]Loot[/b][/i][/td][td][b][i]Recipient[/b][/i][/td][td][b][i]Cost[/b][/i][/td][td][b][i]DKP Per Person[/b][/i][/td][/tr]");
-				DataRow[] loots = dtDKS.Select("LootRaid='" + ev["EventName"] + "'");
-				i++;
-				foreach (DataRow r in loots) 
-				{
-					dkp += (double)r["PTS"] * -1;
-					sw.Write("<tr><td>" + r["EventNameOrLoot"] + "</td><td>" + r["Name"] + "</td><td>" + r["PTS"] + "</td><td>" + (double)r["PTS"] * -1 / ppl * (1 - owner.DKPTax) + "</td></tr>");
-                    sw2.Write("[tr][td]" + r["EventNameOrLoot"] + "[/td][td]" + r["Name"] + "[/td][td]" + r["PTS"] + "[/td][td]" + (double)r["PTS"] * -1 / ppl * (1 - owner.DKPTax) + "[/td][/tr]");			
-				}
-				sw.Write("<tr><td><b><i>Totals:</b></i></td><td>-</td><td>" + dkp * -1 + "</td><td>" + dkp/ppl * (1 - owner.DKPTax) + "</td></tr>");
+                DataRow[] loots = dtDKS.Select("LootRaid='" + ev["EventName"] + "'");
+                i++;
+                foreach (DataRow r in loots)
+                {
+                    dkp += (double)r["PTS"] * -1;
+                    sw.Write("<tr><td>" + r["EventNameOrLoot"] + "</td><td>" + r["Name"] + "</td><td>" + r["PTS"] + "</td><td>" + (double)r["PTS"] * -1 / ppl * (1 - owner.DKPTax) + "</td></tr>");
+                    sw2.Write("[tr][td]" + r["EventNameOrLoot"] + "[/td][td]" + r["Name"] + "[/td][td]" + r["PTS"] + "[/td][td]" + (double)r["PTS"] * -1 / ppl * (1 - owner.DKPTax) + "[/td][/tr]");
+                }
+                sw.Write("<tr><td><b><i>Totals:</b></i></td><td>-</td><td>" + dkp * -1 + "</td><td>" + dkp / ppl * (1 - owner.DKPTax) + "</td></tr>");
                 sw2.Write("[tr][td][b][i]Totals:[/b][/i][/td][td]-[/td][td]" + dkp * -1 + "[/td][td]" + dkp / ppl * (1 - owner.DKPTax) + "[/td][/tr]");
             }
-			sw.Write("</table>\n\n");
+            sw.Write("</table>\n\n");
             sw2.Write("[/table][/p]");
             owner.PBVal += 10;
 
             // Attendance table
-			sw.Write("<table width ='100%' border='1' cellspacing='0' cellpadding='3' bordercolor='#0000ff' bordercolorlight='#000000' bordercolordark='#ffffff' frame='border' rules='all' class='gensmall'>");
+            sw.Write("<table width ='100%' border='1' cellspacing='0' cellpadding='3' bordercolor='#0000ff' bordercolorlight='#000000' bordercolordark='#ffffff' frame='border' rules='all' class='gensmall'>");
             sw2.Write("[p][table]");
-			i=1;
-			sw.Write("<tr><td colspan='" + (5 + dtEL.Select("EventName NOT LIKE '%1'").Length) + "' bgcolor='black'><b>Attendance</b></td></tr>");
+            i = 1;
+            sw.Write("<tr><td colspan='" + (6 + dtEL.Select("EventName NOT LIKE '%1'").Length) + "' bgcolor='black'><b>Attendance</b></td></tr>");
             sw2.Write("[tr][th][b]Attendance[/b][/th][/tr]");
-			sw.Write("<tr><td width='15%'><b><i>Name</b></i></td>");
+            sw.Write("<tr><td width='15%'><b><i>Name</b></i></td>");
             sw2.Write("[tr][td][b][i]Name[/b][/i][/td]");
-			foreach (DataRow ev in dtEL.Select("EventName NOT LIKE '%1'"))
-            { 
+            foreach (DataRow ev in dtEL.Select("EventName NOT LIKE '%1'"))
+            {
                 sw.Write("<td width='15'><b><i>" + i + "</b></i></td>");
                 sw2.Write("[td][b][i]" + i + "[/i][/b][/td]");
                 i++;
             }
-			sw.Write("<td width='15%'><b><i>DKP Net Change</b></i></td><td width='15%'><b><i>DKP Total</b></i><td width='15'></td><td width='*'><b><i>Tier</b></i></td></tr>");
-            sw2.Write("[td][b][i]DKP Net Change[/i][/b][/td][td][b][i]DKP Total[/i][/b][/td][td][/td][td][b][i]Tier[/i][/b][/td][/tr]");
+            sw.Write("<td width='15%'><b><i>DKP Net Change</b></i></td><td width='15%'><b><i>DKP Total</b></i><td width='15'></td><td width='20%'><b><i>Tier</b></i></td><td width='*'><i><b>Last Raid</i></b></td></tr>");
+            sw2.Write("[td][b][i]DKP Net Change[/i][/b][/td][td][b][i]DKP Total[/i][/b][/td][td][/td][td][b][i]Tier[/i][/b][/td][td][b][i]Last Raid[/i][/b][/td][/tr]");
             owner.PBVal += 10;
-			foreach (DataRow r in dtNT.Rows)
-			{
-				earned = 0;
-				if (dtTotal.Select("Name='" + r["Name"] + "'").Length==0) continue;
+            foreach (DataRow r in dtNT.Rows)
+            {
+                earned = 0;
+                if (dtTotal.Select("Name='" + r["Name"] + "'").Length == 0) continue;
 
-				sw.Write("<td>" + r["Name"] + "</td>");
+                sw.Write("<td>" + r["Name"] + "</td>");
                 sw2.Write("[tr][td]" + r["Name"] + "[/td]");
                 int event_counter = 1;
-				foreach (DataRow ev in dtEL.Select("EventName NOT LIKE '%1'","RaidNumber ASC"))
-				{
-					if (dtDKS.Select("Name='" + r["Name"] + "' AND EventNameOrLoot='" + ev["EventName"] + "'").Length>0) 
-					{
-						earned += (double)dtDKS.Select("Name='" + r["Name"] + "' AND EventNameOrLoot='" + ev["EventName"] + "'")[0]["PTS"];
-						sw.Write("<td>•</td>");
-                        sw2.Write("[td]" + event_counter  + "[/td]");
-					}
-					else 
+                foreach (DataRow ev in dtEL.Select("EventName NOT LIKE '%1'", "RaidNumber ASC"))
+                {
+                    if (dtDKS.Select("Name='" + r["Name"] + "' AND EventNameOrLoot='" + ev["EventName"] + "'").Length > 0)
+                    {
+                        earned += (double)dtDKS.Select("Name='" + r["Name"] + "' AND EventNameOrLoot='" + ev["EventName"] + "'")[0]["PTS"];
+                        sw.Write("<td>•</td>");
+                        sw2.Write("[td]" + event_counter + "[/td]");
+                    }
+                    else
                     {
                         sw.Write("<td></td>");
                         sw2.Write("[td][/td]");
                     }
                     event_counter++;
-				}
-				foreach (DataRow deduct in dtDKS.Select("Name='" + r["Name"] + "' AND PTS<0")) earned += (double)deduct["PTS"];
-				totalnetchange += earned;
-				totaldkp += (double)dtTotal.Select("Name='" + r["Name"] + "'")[0]["Total"];
-				sw.Write("<td>" + String.Format("{0:+0.00;-0.00;00.00}",earned) + "</td>");
+                }
+                foreach (DataRow deduct in dtDKS.Select("Name='" + r["Name"] + "' AND PTS<0")) earned += (double)deduct["PTS"];
+                totalnetchange += earned;
+                totaldkp += (double)dtTotal.Select("Name='" + r["Name"] + "'")[0]["Total"];
+                DateTime lastRaid = (DateTime)dtFinal.Select("Name='" + r["Name"] + "'")[0]["LastRaid"];
+
+                sw.Write("<td>" + String.Format("{0:+0.00;-0.00;00.00}",earned) + "</td>");
 				sw.Write("<td>" + String.Format("{0:+0.000#;-0.000#;00.000#}",dtTotal.Select("Name='" + r["Name"]+ "'")[0]["Total"]) + "</td>");
-				sw.Write("<td>" + r["Tier"] + "</td><td>" + String.Format("{0:00.00}",r["TPercent"]) + "% (" + r["NumRaids"] + "/" + dtAllEvents.Rows.Count + ")</td></tr>");
+                sw.Write("<td>" + r["Tier"] + "</td><td>" + String.Format("{0:00.00}", r["TPercent"]) + "% (" + r["NumRaids"] + "/" + dtAllEvents.Rows.Count + ")</td>");
+                sw.Write("<td>" + lastRaid.ToString("MM-dd-yyyy") + " " + (t - lastRaid).TotalDays + "d</td></tr>");
                 sw2.Write("[td]" + String.Format("{0:+0.00;-0.00;00.00}",earned) + "[/td]");
 				sw2.Write("[td]" + String.Format("{0:+0.000#;-0.000#;00.000#}",dtTotal.Select("Name='" + r["Name"]+ "'")[0]["Total"]) + "[/td]");
-				sw2.Write("[td]" + r["Tier"] + "[/td][td]" + String.Format("{0:00.00}",r["TPercent"]) + "% (" + r["NumRaids"] + "/" + dtAllEvents.Rows.Count + ")[/td][/tr]");
+                sw2.Write("[td]" + r["Tier"] + "[/td][td]" + String.Format("{0:00.00}", r["TPercent"]) + "% (" + r["NumRaids"] + "/" + dtAllEvents.Rows.Count + ")[/td]");
+                sw2.Write("[td]" + lastRaid.ToString("MM-dd-yyyy") + " " + (t - lastRaid).TotalDays + "d[/td][/tr]");
 			}
 			sw.Write("<tr><td><b><i>Totals:</b></i></td>");
             sw2.Write("[tr][td][b][i]Totals:[/i][/b][/td]");
@@ -1187,10 +1191,10 @@ namespace ES_DKP_Utils
                 sw2.Write("[td][/td]");
             }
 			sw.Write("<td>" + String.Format("{0:+0.00;-0.00;00.00}",totalnetchange) + "</td>");
-			sw.Write("<td>" + String.Format("{0:0.0#}",totaldkp) + "</td><td></td><td></td></tr>");
+			sw.Write("<td>" + String.Format("{0:0.0#}",totaldkp) + "</td><td></td><td></td><td></td></tr>");
 			sw.Write("</table>\n\n");
             sw2.Write("[td]" + String.Format("{0:+0.00;-0.00;00.00}",totalnetchange) + "[/td]");
-			sw2.Write("[td]" + String.Format("{0:0.0#}",totaldkp) + "[/td][td][/td][td][/td][/tr]");
+			sw2.Write("[td]" + String.Format("{0:0.0#}",totaldkp) + "[/td][td][/td][td][/td][td][/td][/tr]");
 			sw2.Write("[/table][/p]\n\n");
             owner.PBVal += 10;
 

--- a/Raid.cs
+++ b/Raid.cs
@@ -1143,8 +1143,8 @@ namespace ES_DKP_Utils
                 sw2.Write("[td][b][i]" + i + "[/i][/b][/td]");
                 i++;
             }
-            sw.Write("<td width='15%'><b><i>DKP Net Change</b></i></td><td width='15%'><b><i>DKP Total</b></i><td width='15'></td><td width='20%'><b><i>Tier</b></i></td><td width='*'><i><b>Last Raid</i></b></td></tr>");
-            sw2.Write("[td][b][i]DKP Net Change[/i][/b][/td][td][b][i]DKP Total[/i][/b][/td][td][/td][td][b][i]Tier[/i][/b][/td][td][b][i]Last Raid[/i][/b][/td][/tr]");
+            sw.Write("<td width='15%'><b><i>DKP Net Change</b></i></td><td width='15%'><b><i>DKP Total</b></i><td width='15'></td><td width='*'><b><i>Tier</b></i></td><td width='10'><i><b>Age</i></b></td></tr>");
+            sw2.Write("[td][b][i]DKP Net Change[/i][/b][/td][td][b][i]DKP Total[/i][/b][/td][td][/td][td][b][i]Tier[/i][/b][/td][td][b][i]Age[/i][/b][/td][/tr]");
             owner.PBVal += 10;
             foreach (DataRow r in dtNT.Rows)
             {
@@ -1173,15 +1173,16 @@ namespace ES_DKP_Utils
                 totalnetchange += earned;
                 totaldkp += (double)dtTotal.Select("Name='" + r["Name"] + "'")[0]["Total"];
                 DateTime lastRaid = (DateTime)dtFinal.Select("Name='" + r["Name"] + "'")[0]["LastRaid"];
+                int daysSinceLastRaid = (int)(t - lastRaid).TotalDays;
 
                 sw.Write("<td>" + String.Format("{0:+0.00;-0.00;00.00}",earned) + "</td>");
 				sw.Write("<td>" + String.Format("{0:+0.000#;-0.000#;00.000#}",dtTotal.Select("Name='" + r["Name"]+ "'")[0]["Total"]) + "</td>");
                 sw.Write("<td>" + r["Tier"] + "</td><td>" + String.Format("{0:00.00}", r["TPercent"]) + "% (" + r["NumRaids"] + "/" + dtAllEvents.Rows.Count + ")</td>");
-                sw.Write("<td>" + lastRaid.ToString("MM-dd-yyyy") + " " + (t - lastRaid).TotalDays + "d</td></tr>");
+                sw.Write("<td>" + (daysSinceLastRaid >= owner.LastRaidDaysThreshold ? $"{daysSinceLastRaid}d" : "") + "</td></tr>");
                 sw2.Write("[td]" + String.Format("{0:+0.00;-0.00;00.00}",earned) + "[/td]");
 				sw2.Write("[td]" + String.Format("{0:+0.000#;-0.000#;00.000#}",dtTotal.Select("Name='" + r["Name"]+ "'")[0]["Total"]) + "[/td]");
                 sw2.Write("[td]" + r["Tier"] + "[/td][td]" + String.Format("{0:00.00}", r["TPercent"]) + "% (" + r["NumRaids"] + "/" + dtAllEvents.Rows.Count + ")[/td]");
-                sw2.Write("[td]" + lastRaid.ToString("MM-dd-yyyy") + " " + (t - lastRaid).TotalDays + "d[/td][/tr]");
+                sw2.Write("[td]" + (daysSinceLastRaid >= owner.LastRaidDaysThreshold ? $"{daysSinceLastRaid}d" : "") + "[/td][/tr]");
 			}
 			sw.Write("<tr><td><b><i>Totals:</b></i></td>");
             sw2.Write("[tr][td][b][i]Totals:[/i][/b][/td]");

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -47,6 +47,8 @@ namespace ES_DKP_Utils
         private Label lblBackupDirectory;
         private TextBox txtBackupDirectory;
         private Button btnChangeBackupDirectory;
+        private Label lblRaidDays;
+        private TextBox txtRaidDays;
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 		#endregion
 
@@ -170,6 +172,7 @@ namespace ES_DKP_Utils
             iniFile.Configs["Other"].Set("tierbpct", Double.Parse(txtTierBPct.Text));
             iniFile.Configs["Other"].Set("tiercpct", Double.Parse(txtTierCPct.Text));
             iniFile.Configs["Other"].Set("GuildNames", txtGuildNames.Text);
+            iniFile.Configs["Other"].Set("RaidDaysWindow", txtRaidDays.Text);
 
             try { 
 				double d = Double.Parse(txtTax.Text);	
@@ -230,9 +233,11 @@ namespace ES_DKP_Utils
             this.txtGuildNames = new System.Windows.Forms.TextBox();
             this.lblGuildNames = new System.Windows.Forms.Label();
             this.toolTipGuildNames = new System.Windows.Forms.ToolTip(this.components);
+            this.lblRaidDays = new System.Windows.Forms.Label();
             this.lblBackupDirectory = new System.Windows.Forms.Label();
             this.txtBackupDirectory = new System.Windows.Forms.TextBox();
             this.btnChangeBackupDirectory = new System.Windows.Forms.Button();
+            this.txtRaidDays = new System.Windows.Forms.TextBox();
             this.SuspendLayout();
             // 
             // txtLogFile
@@ -263,7 +268,7 @@ namespace ES_DKP_Utils
             // btnOK
             // 
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(94, 291);
+            this.btnOK.Location = new System.Drawing.Point(94, 351);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(72, 32);
             this.btnOK.TabIndex = 6;
@@ -273,7 +278,7 @@ namespace ES_DKP_Utils
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(175, 291);
+            this.btnCancel.Location = new System.Drawing.Point(175, 351);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(72, 32);
             this.btnCancel.TabIndex = 7;
@@ -445,6 +450,18 @@ namespace ES_DKP_Utils
             this.toolTipGuildNames.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
             this.toolTipGuildNames.ToolTipTitle = "Multiple Guild Names";
             // 
+            // lblRaidDays
+            // 
+            this.lblRaidDays.AutoSize = true;
+            this.lblRaidDays.Location = new System.Drawing.Point(41, 279);
+            this.lblRaidDays.Name = "lblRaidDays";
+            this.lblRaidDays.Size = new System.Drawing.Size(59, 13);
+            this.lblRaidDays.TabIndex = 51;
+            this.lblRaidDays.Text = "Raid Days:";
+            this.lblRaidDays.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.toolTipGuildNames.SetToolTip(this.lblRaidDays, "Separate Guild Names with a Pipe\r\n\r\nFor example:\r\nEternal Sovereign|Crusaders Val" +
+        "ourous");
+            // 
             // lblBackupDirectory
             // 
             this.lblBackupDirectory.Location = new System.Drawing.Point(-7, 84);
@@ -469,12 +486,20 @@ namespace ES_DKP_Utils
             this.btnChangeBackupDirectory.Size = new System.Drawing.Size(24, 20);
             this.btnChangeBackupDirectory.TabIndex = 50;
             this.btnChangeBackupDirectory.Click += new System.EventHandler(this.btnChangeBackupDirectory_Click);
-
+            // 
+            // txtRaidDays
+            // 
+            this.txtRaidDays.Location = new System.Drawing.Point(106, 276);
+            this.txtRaidDays.Name = "txtRaidDays";
+            this.txtRaidDays.Size = new System.Drawing.Size(60, 20);
+            this.txtRaidDays.TabIndex = 52;
             // 
             // SettingsDialog
             // 
             this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
-            this.ClientSize = new System.Drawing.Size(337, 335);
+            this.ClientSize = new System.Drawing.Size(337, 395);
+            this.Controls.Add(this.txtRaidDays);
+            this.Controls.Add(this.lblRaidDays);
             this.Controls.Add(this.btnChangeBackupDirectory);
             this.Controls.Add(this.txtBackupDirectory);
             this.Controls.Add(this.lblBackupDirectory);

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -49,6 +49,8 @@ namespace ES_DKP_Utils
         private Button btnChangeBackupDirectory;
         private Label lblRaidDays;
         private TextBox txtRaidDays;
+        private TextBox txtLastRaidThreshold;
+        private Label lblLastRaidThreshhold;
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 		#endregion
 
@@ -66,12 +68,14 @@ namespace ES_DKP_Utils
 			txtLocalDBFile.Text = iniFile.Configs["Files"].GetString("dbfile","");
 			txtOutputDirectory.Text = iniFile.Configs["Files"].GetString("outdir","");
             //txtBackupDirectory.Text = iniFile.Configs["Files"].GetString("backup_directory", "\\backups");
-			txtTax.Text = iniFile.Configs["Other"].GetDouble("tax",0)*100 + "";
-            txtMinDKP.Text = iniFile.Configs["Other"].GetDouble("mindkp", 0) + "";
-            txtTierAPct.Text = iniFile.Configs["Other"].GetDouble("tierapct", 0.60) + "";
-            txtTierBPct.Text = iniFile.Configs["Other"].GetDouble("tierbpct", 0.40) + "";
-            txtTierCPct.Text = iniFile.Configs["Other"].GetDouble("tiercpct", 0.30) + "";
+			txtTax.Text = (iniFile.Configs["Other"].GetDouble("tax",0)*100).ToString();
+            txtMinDKP.Text = iniFile.Configs["Other"].GetDouble("mindkp", 0).ToString();
+            txtTierAPct.Text = iniFile.Configs["Other"].GetDouble("tierapct", 0.60).ToString();
+            txtTierBPct.Text = iniFile.Configs["Other"].GetDouble("tierbpct", 0.40).ToString();
+            txtTierCPct.Text = iniFile.Configs["Other"].GetDouble("tiercpct", 0.30).ToString();
             txtGuildNames.Text = iniFile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
+            txtRaidDays.Text = iniFile.Configs["Other"].GetInt("RaidDaysWindow", 20).ToString();
+            txtLastRaidThreshold.Text = iniFile.Configs["Other"].GetInt("LastRaidDaysThreshold", 7).ToString();
             log.Debug("End Method: frmSettings.frmSettings()");
 		}
 		#endregion
@@ -173,6 +177,7 @@ namespace ES_DKP_Utils
             iniFile.Configs["Other"].Set("tiercpct", Double.Parse(txtTierCPct.Text));
             iniFile.Configs["Other"].Set("GuildNames", txtGuildNames.Text);
             iniFile.Configs["Other"].Set("RaidDaysWindow", txtRaidDays.Text);
+            iniFile.Configs["Other"].Set("LastRaidDaysThreshold", txtLastRaidThreshold.Text);
 
             try { 
 				double d = Double.Parse(txtTax.Text);	
@@ -238,6 +243,8 @@ namespace ES_DKP_Utils
             this.txtBackupDirectory = new System.Windows.Forms.TextBox();
             this.btnChangeBackupDirectory = new System.Windows.Forms.Button();
             this.txtRaidDays = new System.Windows.Forms.TextBox();
+            this.txtLastRaidThreshold = new System.Windows.Forms.TextBox();
+            this.lblLastRaidThreshhold = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // txtLogFile
@@ -453,11 +460,11 @@ namespace ES_DKP_Utils
             // lblRaidDays
             // 
             this.lblRaidDays.AutoSize = true;
-            this.lblRaidDays.Location = new System.Drawing.Point(41, 279);
+            this.lblRaidDays.Location = new System.Drawing.Point(-1, 279);
             this.lblRaidDays.Name = "lblRaidDays";
-            this.lblRaidDays.Size = new System.Drawing.Size(59, 13);
+            this.lblRaidDays.Size = new System.Drawing.Size(101, 13);
             this.lblRaidDays.TabIndex = 51;
-            this.lblRaidDays.Text = "Raid Days:";
+            this.lblRaidDays.Text = "Raid Days Window:";
             this.lblRaidDays.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.toolTipGuildNames.SetToolTip(this.lblRaidDays, "Separate Guild Names with a Pipe\r\n\r\nFor example:\r\nEternal Sovereign|Crusaders Val" +
         "ourous");
@@ -494,10 +501,31 @@ namespace ES_DKP_Utils
             this.txtRaidDays.Size = new System.Drawing.Size(60, 20);
             this.txtRaidDays.TabIndex = 52;
             // 
+            // txtLastRaidThreshold
+            // 
+            this.txtLastRaidThreshold.Location = new System.Drawing.Point(106, 302);
+            this.txtLastRaidThreshold.Name = "txtLastRaidThreshold";
+            this.txtLastRaidThreshold.Size = new System.Drawing.Size(60, 20);
+            this.txtLastRaidThreshold.TabIndex = 54;
+            // 
+            // lblLastRaidThreshhold
+            // 
+            this.lblLastRaidThreshhold.AutoSize = true;
+            this.lblLastRaidThreshhold.Location = new System.Drawing.Point(-1, 305);
+            this.lblLastRaidThreshhold.Name = "lblLastRaidThreshhold";
+            this.lblLastRaidThreshhold.Size = new System.Drawing.Size(105, 13);
+            this.lblLastRaidThreshhold.TabIndex = 53;
+            this.lblLastRaidThreshhold.Text = "Last Raid Threshold:";
+            this.lblLastRaidThreshhold.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.toolTipGuildNames.SetToolTip(this.lblLastRaidThreshhold, "Separate Guild Names with a Pipe\r\n\r\nFor example:\r\nEternal Sovereign|Crusaders Val" +
+        "ourous");
+            // 
             // SettingsDialog
             // 
             this.AutoScaleBaseSize = new System.Drawing.Size(5, 13);
             this.ClientSize = new System.Drawing.Size(337, 395);
+            this.Controls.Add(this.txtLastRaidThreshold);
+            this.Controls.Add(this.lblLastRaidThreshhold);
             this.Controls.Add(this.txtRaidDays);
             this.Controls.Add(this.lblRaidDays);
             this.Controls.Add(this.btnChangeBackupDirectory);

--- a/SettingsDialog.resx
+++ b/SettingsDialog.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnChangeLogFile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
@@ -142,10 +142,7 @@
         rl9AYEyAVCQKpoIdrLsIkIrEwbOg0o7MAok/OO2vIboBg3zbUa/eBXsAAAAASUVORK5CYII=
 </value>
   </data>
-  <metadata name="toolTipGuildNames.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="toolTipGuildNames.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="toolTipGuildNames.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <data name="btnChangeBackupDirectory.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
This addresses a request from Rapitiss to be able to more easily see how long it's been since a raider has been to a raid.

This adds a last raid column that lists the date and number of days since that raiders last raid.  So for raiders who attended the daily report's raid, it would be 0d, and increment out beyond that as they miss consecutive raids.

Also, visual studio randomly did a ton of autoformatting on the code.  I hate to combine that with this PR, but also, I don't know how to back that out easily so screw it.  The changes we care about are all in the `Raid.DailyReport()` function.
