### PR TITLE
Address softlock when automatic backups not configured correctly

### DIFF
--- a/MainClass.cs
+++ b/MainClass.cs
@@ -1736,7 +1736,7 @@ namespace ES_DKP_Utils
 
         private void frmMain_FormClosing(object sender, EventArgs e)
         {
-            if (AutomaticBackups && !(Directory.Exists(BackupDirectory)) {
+            if (AutomaticBackups && !(Directory.Exists(BackupDirectory))) {
                 MessageBox.Show("Cannot automatically backup database - Backup Directory does not exist.  Please check your settings.",
                                 "Automatic DB Backup", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -1736,7 +1736,11 @@ namespace ES_DKP_Utils
 
         private void frmMain_FormClosing(object sender, EventArgs e)
         {
-            if (AutomaticBackups)
+            if (AutomaticBackups && !(Directory.Exists(BackupDirectory)) {
+                MessageBox.Show("Cannot automatically backup database - Backup Directory does not exist.  Please check your settings.",
+                                "Automatic DB Backup", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+            else if (AutomaticBackups)
             {
                 DateTime time = DateTime.UtcNow;
                 Directory.CreateDirectory(BackupDirectory);


### PR DESCRIPTION
Addresses #5 

The program would fail to exit without showing any error when closing it and the backup directory was not properly set.

It doesn't do that now.