### PR TITLE
JSON Serialization

### DIFF
--- a/ES DKP Utils.csproj
+++ b/ES DKP Utils.csproj
@@ -124,6 +124,9 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Nini">
       <Name>Nini</Name>
       <HintPath>Nini.dll</HintPath>

--- a/ES DKP Utils.csproj
+++ b/ES DKP Utils.csproj
@@ -127,6 +127,9 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Nini">
       <Name>Nini</Name>
       <HintPath>Nini.dll</HintPath>

--- a/ES DKP Utils.csproj
+++ b/ES DKP Utils.csproj
@@ -127,12 +127,6 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="Nini">
       <Name>Nini</Name>
       <HintPath>Nini.dll</HintPath>

--- a/ES DKP Utils.csproj
+++ b/ES DKP Utils.csproj
@@ -179,12 +179,14 @@
     <Compile Include="MainClass.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Models\LootModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Models\RaidModel.cs" />
     <Compile Include="RecordLootDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/ES DKP Utils.sln
+++ b/ES DKP Utils.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ES DKP Utils", "ES DKP Utils.csproj", "{5CEA7F7F-3110-4A53-BAB7-22799ED9232A}"
 EndProject
@@ -23,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C947DA43-B536-49FE-88E4-6597F00EC783}
 	EndGlobalSection
 EndGlobal

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -1889,8 +1889,16 @@ namespace ES_DKP_Utils
         {
             log.Debug("Begin Method: mnuExportRaidJson_Click(object,EventArgs) (" + sender.ToString() + "," + e.ToString() + ")");
 
-            string json = JsonConvert.SerializeObject(CurrentRaid);
-            MessageBox.Show(json);
+            if (CurrentRaid != null)
+            {
+                CurrentRaid.SaveJsonRaidModel();
+                MessageBox.Show("Successfully exported JSON Raid Model", "Success!");
+            }
+            else
+            {
+                MessageBox.Show("No raid is currently loaded", "Nope!");
+            }
+            
 
             log.Debug("End Method: mnuExportRaidJson_Click()");
         }

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -152,6 +152,9 @@ namespace ES_DKP_Utils
 		}
 
         private System.Double _MinDKP;
+        /// <summary>
+        /// Minimum balance to have tier considered (Tier 'D' limit, colloquially)
+        /// </summary>
         public System.Double MinDKP
         {
             get { return _MinDKP; }
@@ -258,6 +261,8 @@ namespace ES_DKP_Utils
         #endregion
 
         public int LastRaidDaysThreshold { get; set; }
+        public bool AutosaveJsonRaidModels { get; set; } = true;
+        public string JsonRaidModelDirectory { get; set; } = Path.Combine(Directory.GetCurrentDirectory(), "jsonRaidModels");
 
         private IConfigSource inifile;
         private LogParser parser;
@@ -294,19 +299,24 @@ namespace ES_DKP_Utils
 			try 
 			{
 				inifile = new IniConfigSource(Directory.GetCurrentDirectory() + "\\settings.ini");
+
 				DBString = inifile.Configs["Files"].GetString("dbfile", Directory.GetCurrentDirectory() + "\\DKP.mdb");
-				LogFile = inifile.Configs["Files"].GetString("logfile","");
+				LogFile = inifile.Configs["Files"].GetString("logfile", "");
 				OutputDirectory = inifile.Configs["Files"].GetString("outdir", Directory.GetCurrentDirectory());
                 BackupDirectory = inifile.Configs["Files"].GetString("backupdir", Directory.GetCurrentDirectory());
-				DKPTax = inifile.Configs["Other"].GetDouble("tax",0.0);
+                JsonRaidModelDirectory = inifile.Configs["Files"].GetString("JsonRaidModelDirectory", JsonRaidModelDirectory);
+
+                AutomaticBackups = inifile.Configs["Other"].GetBoolean("AutomaticBackups", true);
+                AutosaveJsonRaidModels = inifile.Configs["Other"].GetBoolean("AutosaveJsonRaidModels", AutosaveJsonRaidModels);
+                DKPTax = inifile.Configs["Other"].GetDouble("tax", 0.0);
+                GuildNames = inifile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
+                LastRaidDaysThreshold = inifile.Configs["Other"].GetInt("LastRaidDaysThreshold", 7);
                 MinDKP = inifile.Configs["Other"].GetDouble("mindkp", 0);
+                RaidDaysWindow = inifile.Configs["Other"].GetInt("RaidDaysWindow", 20);
                 TierAPct = inifile.Configs["Other"].GetDouble("tierapct", 0.60);
                 TierBPct = inifile.Configs["Other"].GetDouble("tierbpct", 0.30);
                 TierCPct = inifile.Configs["Other"].GetDouble("tiercpct", 0.01);
-                GuildNames = inifile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
-                AutomaticBackups = inifile.Configs["Other"].GetBoolean("AutomaticBackups", true);
-                RaidDaysWindow = inifile.Configs["Other"].GetInt("RaidDaysWindow", 20);
-                LastRaidDaysThreshold = inifile.Configs["Other"].GetInt("LastRaidDaysThreshold", 7);
+
                 log.Info("Read settings from INI: DBFile=" + DBString + ", LogFile=" + LogFile + ", OutputDirectory="
                     + OutputDirectory + ", DKPTax=" + DKPTax + ", GuildNames=" + GuildNames);
 
@@ -333,20 +343,25 @@ namespace ES_DKP_Utils
 					inifile = new IniConfigSource(Directory.GetCurrentDirectory() + "\\settings.ini");
 					inifile.AddConfig("Files");
 					inifile.AddConfig("Other");
+
 					LogFile = inifile.Configs["Files"].GetString("logfile","");
 					DBString = inifile.Configs["Files"].GetString("dbfile", Directory.GetCurrentDirectory() + "\\DKP.mdb");
 					OutputDirectory = inifile.Configs["Files"].GetString("outdir", Directory.GetCurrentDirectory());
                     BackupDirectory = inifile.Configs["Files"].GetString("backupdir", Directory.GetCurrentDirectory());
+                    JsonRaidModelDirectory = inifile.Configs["Files"].GetString("JsonRaidModelDirectory", JsonRaidModelDirectory);
+
+                    AutomaticBackups = inifile.Configs["Other"].GetBoolean("AutomaticBackups", true);
+                    AutosaveJsonRaidModels = inifile.Configs["Other"].GetBoolean("AutosaveJsonRaidModels", AutosaveJsonRaidModels);
                     DKPTax = inifile.Configs["Other"].GetDouble("tax",0.0);
+                    GuildNames = inifile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
+                    LastRaidDaysThreshold = inifile.Configs["Other"].GetInt("LastRaidDaysThreshold", 7);
                     MinDKP = inifile.Configs["Other"].GetDouble("mindkp", 0);
+                    RaidDaysWindow = inifile.Configs["Other"].GetInt("RaidDaysWindow", 20);
                     TierAPct = inifile.Configs["Other"].GetDouble("tierapct", 0.60);
                     TierBPct = inifile.Configs["Other"].GetDouble("tierbpct", 0.30);
                     TierCPct = inifile.Configs["Other"].GetDouble("tiercpct", 0.01);
-                    GuildNames = inifile.Configs["Other"].GetString("GuildNames", "Eternal Sovereign");
-                    RaidDaysWindow = inifile.Configs["Other"].GetInt("RaidDaysWindow", 20);
-                    LastRaidDaysThreshold = inifile.Configs["Other"].GetInt("LastRaidDaysThreshold", 7);
-                    AutomaticBackups = inifile.Configs["Other"].GetBoolean("AutomaticBackups", true);
-					inifile.Save();
+
+                    inifile.Save();
 					log.Info("Read settings from INI: dbFile=" + DBString + ", logFile=" + LogFile
                         + ", outDir=" + OutputDirectory + ", tax=" + DKPTax + ", mindkp=" + MinDKP + ", GuildNames=" + GuildNames);
 				} 

--- a/Models/LootModel.cs
+++ b/Models/LootModel.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ES_DKP_Utils.Models
+{
+    public class LootModel
+    {
+        /// <summary>
+        /// Name of Loot Awarded
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Name of Raider loot was awarded to
+        /// </summary>
+        public string Raider { get; set; }
+
+        /// <summary>
+        /// Amount of Points loot is worth
+        /// </summary>
+        public double Points { get; set; }
+
+        public LootModel(string name, string raider, double points)
+        {
+            this.Name = name;
+            this.Raider = raider;
+            this.Points = points;
+        }
+    }
+}

--- a/Models/RaidModel.cs
+++ b/Models/RaidModel.cs
@@ -9,21 +9,11 @@ namespace ES_DKP_Utils
 {
     public class RaidModel
     {
-        public DateTime Date { get; set; }
+        public DateTime Date { get; set; } = new DateTime();
         public string Name { get; set; }
-        public List<string> Raiders { get; set; }
+        public double AttendanceMultiplier { get; set; } = 1.0;
+        public List<string> Raiders { get; set; } = new List<string>();
 
-        /// <summary>
-        /// List of Tuples representing awarded loots in Loot, Raider, Price order.
-        /// </summary>
-        public List<LootModel> Loots { get; set; }
-
-        public RaidModel()
-        {
-            Date = new DateTime();
-            Name = "";
-            Raiders = new List<string>();
-            Loots = new List<LootModel>();
-        }
+        public List<LootModel> Loots { get; set; } = new List<LootModel>();
     }
 }

--- a/Models/RaidModel.cs
+++ b/Models/RaidModel.cs
@@ -1,0 +1,29 @@
+﻿using ES_DKP_Utils.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ES_DKP_Utils
+{
+    public class RaidModel
+    {
+        public DateTime Date { get; set; }
+        public string Name { get; set; }
+        public List<string> Raiders { get; set; }
+
+        /// <summary>
+        /// List of Tuples representing awarded loots in Loot, Raider, Price order.
+        /// </summary>
+        public List<LootModel> Loots { get; set; }
+
+        public RaidModel()
+        {
+            Date = new DateTime();
+            Name = "";
+            Raiders = new List<string>();
+            Loots = new List<LootModel>();
+        }
+    }
+}

--- a/Models/RaidModel.cs
+++ b/Models/RaidModel.cs
@@ -11,9 +11,20 @@ namespace ES_DKP_Utils
     {
         public DateTime Date { get; set; } = new DateTime();
         public string Name { get; set; }
-        public double AttendanceMultiplier { get; set; } = 1.0;
-        public List<string> Raiders { get; set; } = new List<string>();
 
+        /// <summary>
+        /// Amount of attendance this raid is worth
+        /// </summary>
+        public double Attendance { get; set; } = 1.0;
+        
+        /// <summary>
+        /// List of raiders who have attended the raid
+        /// </summary>
+        public List<string> Raiders { get; set; } = new List<string>();
+        
+        /// <summary>
+        /// List of awarded loots for a given raid
+        /// </summary>
         public List<LootModel> Loots { get; set; } = new List<LootModel>();
     }
 }

--- a/Raid.cs
+++ b/Raid.cs
@@ -869,7 +869,7 @@ namespace ES_DKP_Utils
             {
                 Name = RaidName,
                 Date = RaidDate,
-                AttendanceMultiplier = DoubleTier ? 2.0 : 1.0
+                Attendance = DoubleTier ? 2.0 : 1.0
             };
 
             DataRow[] modelLoader = dbRaid.Select();

--- a/Raid.cs
+++ b/Raid.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Collections;
+using System.Linq;
+using Newtonsoft.Json;
 
 namespace ES_DKP_Utils
 {
@@ -819,6 +821,11 @@ namespace ES_DKP_Utils
                     MessageBox.Show("Could not open data connection. \n(" + ex.Message + ")", "Error");
                 }
                 finally { dbConnect.Close(); }
+            }
+
+            if (true)
+            {
+                MessageBox.Show(JsonConvert.SerializeObject(this));
             }
 
             log.Debug("End Method: Raid.SyncRaid()");

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Adds the ability to serialize raids as JSON objects to provide a means to communicate with other programs.

Includes:
* Writes JSON files to a directory (default: `$CWD\jsonRaidModels`) whenever a raid is saved
* Can export through a menu option to the same locatoin through a new DKP->Export menu
* Export location configurable in the INI file as `Files->JsonRaidModelDirectory`
* Auto export functionality also configurable in the INI file as `Other->AutosaveJsonRaidModels`

<details>
<summary>Example JSON File (Pretty Printed)</summary>

Resultant files are generally a single line object. Pretty printed here for better examination.

```json
{
    "Date": "2021-06-19T00:00:00",
    "Name": "TestRaid",
    "AttendanceMultiplier": 2.0,
    "Raiders": [
        "Westwynd",
        "Aamsung",
        "Amadues",
        "Beonono",
        "Thronk",
        "Aniea",
        "Burkeena",
        "Sonyan",
        "Lorron",
        "Ogresmedic",
        "Lorai",
        "Kallel",
        "Amageiing",
        "Faeodorus",
        "Shislak",
        "Fishlips",
        "Rapitiss",
        "Deadgnomewalkin",
        "Zebraiz",
        "Vividia",
        "Phaolin",
        "Burkx",
        "Bubbakat",
        "Gandiyen",
        "Tanluyen",
        "Dirtmunch",
        "Alsmack",
        "Kazh",
        "Bethanny",
        "Fafhurd",
        "Spoiledbrat",
        "Negdani",
        "Karome",
        "Renfoe",
        "Defector",
        "Kaputzie",
        "Daewar",
        "Fazin",
        "Lalane"
    ],
    "Loots": [
        {
            "Name": "Diamondized Restless Ore",
            "Raider": "Alsmack",
            "Points": 10800.0
        },
        {
            "Name": "Diamondized Restless Ore",
            "Raider": "Kazh",
            "Points": 10800.0
        },
        {
            "Name": "Diamondized Restless Ore",
            "Raider": "Rapitiss",
            "Points": 10800.0
        }
    ]
}
```

</details>