### PR TITLE
Feature: Export *all* raids to JSON

### DIFF
--- a/ES DKP Utils.csproj
+++ b/ES DKP Utils.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.21022</ProductVersion>
@@ -28,7 +28,7 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/Models/RaidModel.cs
+++ b/Models/RaidModel.cs
@@ -9,7 +9,14 @@ namespace ES_DKP_Utils
 {
     public class RaidModel
     {
+        /// <summary>
+        /// Date the raid took place
+        /// </summary>
         public DateTime Date { get; set; } = new DateTime();
+
+        /// <summary>
+        /// Name of the raid
+        /// </summary>
         public string Name { get; set; }
 
         /// <summary>

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ES_DKP_Utils.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Raid.cs
+++ b/Raid.cs
@@ -183,6 +183,9 @@ namespace ES_DKP_Utils
 
             try
             {
+                // TODO: make raid names SQL safe
+                // erroring raid 12/21/2004 "L'Fay Epic" because it screws up quotation marks:
+                // 2023-01-16 13:55:26,717 [1] ERROR ES_DKP_Utils.Raid [(null)] - Failed to load raid: Syntax error (missing operator) in query expression '(Date=#12/21/2004# AND (((EventNameOrLoot LIKE 'L'Fay Epic%' AND LootRaid NOT LIKE '__%') OR LootRaid LIKE 'L'Fay Epic%') AND EventNameOrLoot NOT LIKE '%1') )'.
                 string query = "SELECT * FROM DKS WHERE (Date=#" + RaidDate.Month + "/" + RaidDate.Day + "/" + RaidDate.Year + "# AND (((EventNameOrLoot LIKE '" + RaidName + "%' AND LootRaid NOT LIKE '__%') OR LootRaid LIKE '" + RaidName + "%') AND EventNameOrLoot NOT LIKE '%1') )";
                 dkpDA.SelectCommand = new OleDbCommand(query, dbConnect);
                 dbConnect.Open();
@@ -839,14 +842,17 @@ namespace ES_DKP_Utils
         {
             RaidModel raidModel = GenerateRaidModel();
 
+            string fileName = $"{this.RaidDate.ToString("yyyy-MM-dd")}-{this.RaidName}.json";
+            foreach (char c in System.IO.Path.GetInvalidFileNameChars())
+            {
+                fileName = fileName.Replace(c, '_');
+            }
+
             try
             {
                 Directory.CreateDirectory(owner.JsonRaidModelDirectory);
                 File.WriteAllText(
-                    Path.Combine(
-                        owner.JsonRaidModelDirectory,
-                        $"{this.RaidDate.ToString("yyyy-MM-dd")}-{this.RaidName}.json"
-                    ),
+                    Path.Combine(owner.JsonRaidModelDirectory, fileName),
                     JsonConvert.SerializeObject(raidModel)
                 );
             }

--- a/app.config
+++ b/app.config
@@ -5,22 +5,22 @@
   </configSections>
   
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
 
   <log4net>
     <root>
-      <level value="ALL" />
-      <appender-ref ref="FileAppender" />
+      <level value="ALL"/>
+      <appender-ref ref="FileAppender"/>
     </root>
     <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
-      <file value="debug.log" />
-      <appendToFile value="true" />
-      <rollingStyle value="Date" />
-      <maxSizeRollBackups value="10" />
-      <datePattern value="yyyyMMdd" />
+      <file value="debug.log"/>
+      <appendToFile value="true"/>
+      <rollingStyle value="Date"/>
+      <maxSizeRollBackups value="10"/>
+      <datePattern value="yyyyMMdd"/>
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline"/>
       </layout>
     </appender>
   </log4net>


### PR DESCRIPTION
Adds a feature that exports all raids to the previously made JSON structure. This will allow us to import these into a different system programmatically.

This is really slow; it has to load the raid from this massive table in the super inefficient way that `LoadRaid()` works for every raid.

I can limit it by date in code, not configurable yet, to do more manageable chunks.

Also some extras in here from moving to Visual Studio 2022.